### PR TITLE
Dev

### DIFF
--- a/UserDB/UserDBmain.py
+++ b/UserDB/UserDBmain.py
@@ -120,9 +120,9 @@ class UserDB:
                     else:
                         return False
                 else:
-                    self.entry_var_upgrade(call_tup[0])
+                    # self.entry_var_upgrade(call_tup[0])
                     return self.db[call_tup[0]]
-            self.entry_var_upgrade(call_str)
+            # self.entry_var_upgrade(call_str)
             return self.db[call_str]
         return False
 

--- a/ax25/ax25Connection.py
+++ b/ax25/ax25Connection.py
@@ -232,11 +232,11 @@ class AX25Conn(object):
         """ User DB Entry """
         # self.user_db = USER_DB
         self.user_db_ent = False
+        self.cli_language = 0
         self.set_user_db_ent()
         """ Station Individual Parameter """
         self.set_packet_param()
         """ Init CLI """
-        self.cli_language = 0
         self.cli = cli.cliMain.NoneCLI(self)
         self.cli_type = ''
         if self.stat_cfg.stat_parm_pipe is None:
@@ -386,8 +386,12 @@ class AX25Conn(object):
                     self.user_db_ent.Language = 0
                 else:
                     self.user_db_ent.Language = int(self.gui.language)
-                    self.cli_language = int(self.gui.language)
+            self.cli_language = self.user_db_ent.Language
             self.set_distance()
+
+    def set_user_db_language(self, lang_ind: int):
+        self.user_db_ent.Language = int(lang_ind)
+        self.cli_language = int(lang_ind)
 
     def set_distance(self):
         if self.user_db_ent:

--- a/ax25/ax25Connection.py
+++ b/ax25/ax25Connection.py
@@ -230,7 +230,6 @@ class AX25Conn(object):
         """ Encoding """
         self.encoding = 'CP437'     # 'UTF-8'
         """ User DB Entry """
-        # self.user_db = USER_DB
         self.user_db_ent = False
         self.cli_language = 0
         self.set_user_db_ent()

--- a/ax25/ax25Statistics.py
+++ b/ax25/ax25Statistics.py
@@ -4,11 +4,10 @@ from datetime import timedelta
 
 import pickle
 
-from UserDB.UserDBmain import USER_DB
 from constant import CFG_mh_data_file, CFG_port_stat_data_file
 from fnc.cfg_fnc import cleanup_obj_dict, set_obj_att
 from fnc.socket_fnc import check_ip_add_format
-from fnc.str_fnc import conv_time_for_sorting, get_timedelta_str
+from fnc.str_fnc import conv_time_for_sorting
 
 
 def get_time_str():
@@ -303,92 +302,6 @@ class MH(object):
 
     def mh_set_ip(self, call: str, axip: (str, int)):
         self.calls[call].axip_add = axip
-
-    def mh_out_cli(self, max_ent=20):
-        out = '\r'
-        # out += '\r                       < MH - List >\r\r'
-        c = 0
-        max_c = 0
-        """
-        tp = 0
-        tb = 0
-        rj = 0
-        """
-        sort_list = self.get_sort_mh_entry('last', False)
-
-        for call in list(sort_list.keys()):
-            max_c += 1
-            if max_c > max_ent:
-                break
-            time_delta_str = get_timedelta_str(sort_list[call].last_seen)
-
-            out += f'{time_delta_str} P:{sort_list[call].port:4} {sort_list[call].own_call:9}'.ljust(27, " ")
-            """
-            tp += sort_list[call].pac_n
-            tb += sort_list[call].byte_n
-            rj += sort_list[call].rej_n
-            """
-            c += 1
-            if c == 2:  # Breite
-                c = 0
-                out += '\r'
-        """
-        out += '\r'
-        out += '\rTotal Packets Rec.: ' + str(tp)
-        out += '\rTotal REJ-Packets Rec.: ' + str(rj)
-        out += '\rTotal Bytes Rec.: ' + str(tb)
-        """
-        out += '\r'
-
-        return out
-
-    def mh_long_out_cli(self, max_ent=10):
-        out = '\r'
-        out += "-----Time-Port---Call------via-------LOC------Dist(km)--Type---Packets\r"
-        max_c = 0
-        """
-        tp = 0
-        tb = 0
-        rj = 0
-        """
-        sort_list = self.get_sort_mh_entry('last', False)
-
-        for call in list(sort_list.keys()):
-            max_c += 1
-            if max_c > max_ent:
-                break
-            time_delta_str = get_timedelta_str(sort_list[call].last_seen)
-            via = sort_list[call].route
-            if via:
-                via = via[-1]
-            else:
-                via = ''
-            loc = ''
-            dis = ''
-            typ = ''
-            userdb_ent = USER_DB.get_entry(sort_list[call].own_call, add_new=False)
-            if userdb_ent:
-                loc = userdb_ent.LOC
-                if userdb_ent.Distance:
-                    dis = str(userdb_ent.Distance)
-                typ = userdb_ent.TYP
-
-            out += (f' {time_delta_str:9}{sort_list[call].port:7}{sort_list[call].own_call:10}'
-                    f'{via:10}{loc:9}{dis:10}{typ:7}{sort_list[call].pac_n}')
-            """
-            tp += sort_list[call].pac_n
-            tb += sort_list[call].byte_n
-            rj += sort_list[call].rej_n
-            """
-            out += '\r'
-        out += '\r'
-        """
-        out += '\rTotal Packets Rec.: ' + str(tp)
-        out += '\rTotal REJ-Packets Rec.: ' + str(rj)
-        out += '\rTotal Bytes Rec.: ' + str(tb)
-        out += '\r'
-        """
-        return out
 
     def mh_out_beacon(self, max_ent=12):
         _tmp = self.get_sort_mh_entry('last', False)

--- a/ax25/ax25Statistics.py
+++ b/ax25/ax25Statistics.py
@@ -87,7 +87,8 @@ class MH(object):
         self.calls: {str: MyHeard} = {}
         for call in mh_load:
             self.calls[call] = set_obj_att(new_obj=MyHeard(), input_obj=mh_load[call])
-
+            # Fix: Delete empty Routes in routes entry
+            # self.calls[call].all_routes = list(filter(lambda a: a != [], self.calls[call].all_routes))
         try:
             with open(CFG_port_stat_data_file, 'rb') as inp:
                 self.port_statistik_DB = pickle.load(inp)
@@ -231,11 +232,11 @@ class MH(object):
                 if call.c_bit:
                     ent.route.append(str(call.call_str))
                     _last_digi = str(call.call_str)
-        if digi and ent.route:
+        if ent.route and digi:
             ent.route = ent.route[:-1]
-
         if ent.route not in ent.all_routes:
             ent.all_routes.append(list(ent.route))
+
         # Update AXIP Address
         if ax25_frame.axip_add[0]:
             if ent.axip_add[0]:
@@ -292,6 +293,7 @@ class MH(object):
         self.calls: {str: MyHeard}
         for k in self.calls.keys():
             flag: MyHeard = self.calls[k]
+
             key: str = {
                 'last': conv_time_for_sorting(flag.last_seen),
                 'first': conv_time_for_sorting(flag.first_seen),
@@ -301,7 +303,7 @@ class MH(object):
                 'dist': str(flag.distance),
                 'pack': str(flag.pac_n),
                 'rej': str(flag.rej_n),
-                'route': str(max(flag.all_routes)),
+                'route': str(flag.route),
                 'axip': str(flag.axip_add),
                 'axipfail': str(flag.axip_fail),
             }[flag_str]

--- a/ax25/ax25Statistics.py
+++ b/ax25/ax25Statistics.py
@@ -105,6 +105,8 @@ class MH(object):
 
         self.dx_alarm_trigger = False
         self.last_dx_alarm = time.time()
+        self.dx_alarm_hist = []
+        self.dx_alarm_perma_hist = {}
         self.parm_new_call_alarm = False
         self.parm_distance_alarm = 50
         self.parm_lastseen_alarm = 1
@@ -113,10 +115,17 @@ class MH(object):
     def __del__(self):
         pass
 
-    def _set_dx_alarm(self, port_id: int):
+    def _set_dx_alarm(self, ent, port_id: int):
         if port_id in self.parm_alarm_ports:
             self.dx_alarm_trigger = True
             self.last_dx_alarm = time.time()
+            _now = datetime.now()
+            self.dx_alarm_hist.append(ent.own_call)
+            self.dx_alarm_perma_hist[str(ent.own_call)] = _now, ent
+
+    def reset_dx_alarm_his(self):
+        self.dx_alarm_hist = []
+        self.dx_alarm_trigger = False
 
     def bw_mon_inp(self, ax25_frame, port_id):
         if port_id not in self.port_statistik_DB.keys():
@@ -188,6 +197,7 @@ class MH(object):
             self.calls[ent].axip_add = axip_add
 
     def mh_inp(self, ax25_frame, port_name, port_id, digi=''):
+        _dx_alarm = False
         if not digi:
             ########################
             # Port Stat
@@ -204,13 +214,13 @@ class MH(object):
         if call_str not in self.calls.keys():
             ent = MyHeard()
             if self.parm_new_call_alarm:
-                self._set_dx_alarm(port_id)
+                _dx_alarm = True
         else:
             ent = self.calls[call_str]
         _t_delta = datetime.now() - ent.last_seen
         if self.parm_lastseen_alarm:
             if _t_delta.days >= self.parm_lastseen_alarm:
-                self._set_dx_alarm(port_id)
+                _dx_alarm = True
         ent.last_seen = datetime.now()
         ent.own_call = call_str
         ent.pac_n += 1
@@ -253,7 +263,9 @@ class MH(object):
             ent.distance = float(db_ent.Distance)
         if self.parm_distance_alarm:
             if ent.distance >= self.parm_distance_alarm:
-                self._set_dx_alarm(port_id)
+                _dx_alarm = True
+        if _dx_alarm:
+            self._set_dx_alarm(port_id=port_id, ent=ent)
 
         self.calls[call_str] = ent
 

--- a/ax25/ax25Statistics.py
+++ b/ax25/ax25Statistics.py
@@ -1,3 +1,4 @@
+import time
 from collections import deque
 from datetime import datetime
 from datetime import timedelta
@@ -102,12 +103,17 @@ class MH(object):
                     setattr(self.calls[call], att, getattr(MyHeard, att))
 
         self.dx_alarm_trigger = False
+        self.last_dx_alarm = time.time()
         self.parm_new_call_alarm = False
         self.parm_distance_alarm = 50
         self.parm_lastseen_alarm = 1
 
     def __del__(self):
         pass
+
+    def _set_dx_alarm(self):
+        self.dx_alarm_trigger = True
+        self.last_dx_alarm = time.time()
 
     def bw_mon_inp(self, ax25_frame, port_id):
         if port_id not in self.port_statistik_DB.keys():
@@ -191,13 +197,13 @@ class MH(object):
         if call_str not in self.calls.keys():
             ent = MyHeard()
             if self.parm_new_call_alarm:
-                self.dx_alarm_trigger = True
+                self._set_dx_alarm()
         else:
             ent = self.calls[call_str]
         _t_delta = datetime.now() - ent.last_seen
         if self.parm_lastseen_alarm:
             if _t_delta.days >= self.parm_lastseen_alarm:
-                self.dx_alarm_trigger = True
+                self._set_dx_alarm()
         ent.last_seen = datetime.now()
         ent.own_call = call_str
         ent.pac_n += 1
@@ -236,7 +242,7 @@ class MH(object):
             ent.distance = float(db_ent.Distance)
         if self.parm_distance_alarm:
             if ent.distance >= self.parm_distance_alarm:
-                self.dx_alarm_trigger = True
+                self._set_dx_alarm()
 
         self.calls[call_str] = ent
 

--- a/ax25/ax25Statistics.py
+++ b/ax25/ax25Statistics.py
@@ -107,13 +107,15 @@ class MH(object):
         self.parm_new_call_alarm = False
         self.parm_distance_alarm = 50
         self.parm_lastseen_alarm = 1
+        self.parm_alarm_ports = []
 
     def __del__(self):
         pass
 
-    def _set_dx_alarm(self):
-        self.dx_alarm_trigger = True
-        self.last_dx_alarm = time.time()
+    def _set_dx_alarm(self, port_id: int):
+        if port_id in self.parm_alarm_ports:
+            self.dx_alarm_trigger = True
+            self.last_dx_alarm = time.time()
 
     def bw_mon_inp(self, ax25_frame, port_id):
         if port_id not in self.port_statistik_DB.keys():
@@ -197,13 +199,13 @@ class MH(object):
         if call_str not in self.calls.keys():
             ent = MyHeard()
             if self.parm_new_call_alarm:
-                self._set_dx_alarm()
+                self._set_dx_alarm(port_id)
         else:
             ent = self.calls[call_str]
         _t_delta = datetime.now() - ent.last_seen
         if self.parm_lastseen_alarm:
             if _t_delta.days >= self.parm_lastseen_alarm:
-                self._set_dx_alarm()
+                self._set_dx_alarm(port_id)
         ent.last_seen = datetime.now()
         ent.own_call = call_str
         ent.pac_n += 1
@@ -242,7 +244,7 @@ class MH(object):
             ent.distance = float(db_ent.Distance)
         if self.parm_distance_alarm:
             if ent.distance >= self.parm_distance_alarm:
-                self._set_dx_alarm()
+                self._set_dx_alarm(port_id)
 
         self.calls[call_str] = ent
 

--- a/ax25aprs/aprs_dec.py
+++ b/ax25aprs/aprs_dec.py
@@ -140,6 +140,7 @@ def format_aprs_msg(aprs_frame: aprslib.parse, own_locator, full_aprs_frame: apr
     ret = ''
     dist = ''
     typ = ''
+    loc = ''
     db_ent = USER_DB.get_entry(full_aprs_frame['from'], add_new=add_new_user)
     for k in aprs_frame:
         # print(f"{k}: {aprs_frame[k]}")
@@ -175,13 +176,8 @@ def format_aprs_msg(aprs_frame: aprslib.parse, own_locator, full_aprs_frame: apr
                     loc = coordinates_to_locator(latitude=aprs_frame['latitude'],
                                                  longitude=aprs_frame['longitude'])
                     ret += f"├►LOCATOR      : {loc}\n"
-                    if db_ent:
-                        if not db_ent.LOC:
-                            db_ent.LOC = loc
-                        if not db_ent.Lat:
-                            db_ent.Lat = aprs_frame['latitude']
-                            db_ent.Lon = aprs_frame['longitude']
-                    if own_locator:
+
+                    if own_locator and loc:
                         dist = locator_distance(own_locator, loc)
                         ret += f"├►DISTANCE     : {dist} km\n"
                     # if db_ent:
@@ -202,12 +198,14 @@ def format_aprs_msg(aprs_frame: aprslib.parse, own_locator, full_aprs_frame: apr
         if k in ['weather', 'wx']:
             typ = 'APRS-WX'
     if db_ent:
-        # if not db_ent.Distance:
-        if db_ent.LOC and own_locator:
-            db_ent.Distance = locator_distance(own_locator, db_ent.LOC)
-            dist = locator_distance(own_locator, db_ent.LOC)
-            if not db_ent.TYP and typ:
-                db_ent.TYP = typ
+        if loc:
+            db_ent.LOC = loc
+            db_ent.Lat = aprs_frame['latitude']
+            db_ent.Lon = aprs_frame['longitude']
+            if type(dist) == float:
+                db_ent.Distance = float(dist)
+        if not db_ent.TYP and typ:
+            db_ent.TYP = typ
 
     return ret, dist
 

--- a/ax25aprs/aprs_dec.py
+++ b/ax25aprs/aprs_dec.py
@@ -141,10 +141,7 @@ def format_aprs_msg(aprs_frame: aprslib.parse, own_locator, full_aprs_frame: apr
     dist = ''
     typ = ''
     loc = ''
-    db_ent = USER_DB.get_entry(full_aprs_frame['from'], add_new=add_new_user)
     for k in aprs_frame:
-        # print(f"{k}: {aprs_frame[k]}")
-
         if aprs_frame[k]:
             # if k not in ['from', 'to',  'symbol_table', 'symbol', 'subpacket', 'weather']:
             if k not in ['from', 'to', 'raw', 'symbol_table', 'symbol', 'subpacket', 'weather']:
@@ -197,15 +194,17 @@ def format_aprs_msg(aprs_frame: aprslib.parse, own_locator, full_aprs_frame: apr
                     ret += f"├►{k.upper().ljust(13)}: {aprs_frame[k]}\n"
         if k in ['weather', 'wx']:
             typ = 'APRS-WX'
-    if db_ent:
-        if loc:
+
+    if loc:
+        db_ent = USER_DB.get_entry(full_aprs_frame.get('from', ''), add_new=add_new_user)
+        if db_ent:
             db_ent.LOC = loc
             db_ent.Lat = aprs_frame['latitude']
             db_ent.Lon = aprs_frame['longitude']
             if type(dist) == float:
                 db_ent.Distance = float(dist)
-        if not db_ent.TYP and typ:
-            db_ent.TYP = typ
+            if not db_ent.TYP and typ:
+                db_ent.TYP = typ
 
     return ret, dist
 

--- a/ax25aprs/aprs_station.py
+++ b/ax25aprs/aprs_station.py
@@ -774,13 +774,13 @@ class APRS_ais(object):
                 _dist = _user_db_ent.Distance
             pack['distance'] = _dist
             pack['locator'] = _loc
-
+            pack['tr_alarm'] = self._tracer_check_alarm(pack)
             if _k in self.be_tracer_traced_packets.keys():
                 self.be_tracer_traced_packets[_k].append(pack)
             else:
                 self.be_tracer_traced_packets[_k] = deque([pack], maxlen=500)
             # print(f'Tracer RX dict: {self.be_tracer_traced_packets}')
-            self._tracer_check_alarm(pack)
+            # self._tracer_check_alarm(pack)
             self.tracer_update_gui()
             return True
         return False
@@ -791,6 +791,8 @@ class APRS_ais(object):
         _dist = pack.get('distance', 0)
         if _dist >= self.be_tracer_alarm_range:
             self._be_tracer_is_alarm = True
+            return True
+        return False
 
     def tracer_is_alarm(self):
         return self._be_tracer_is_alarm

--- a/ax25aprs/aprs_station.py
+++ b/ax25aprs/aprs_station.py
@@ -677,6 +677,7 @@ class APRS_ais(object):
             if time.time() > self._be_auto_tracer_timer:
                 return
             if time.time() > self._be_tracer_interval_timer:
+                print(f"Auto-Tracer timer: {round(self._be_auto_tracer_timer - time.time())}")
                 self.tracer_sendit()
                 return
 

--- a/ax25aprs/aprs_station.py
+++ b/ax25aprs/aprs_station.py
@@ -381,29 +381,6 @@ class APRS_ais(object):
     def get_wx_data(self):
         return dict(self.aprs_wx_msg_pool)
 
-    def get_wx_cli_out(self, max_ent=10):
-        _data = self.get_wx_entry_sort_distance()
-        if not _data:
-            return ''
-        max_c = 0
-        out = '\r-----Last-Port--Call------LOC-------------Temp-Press---Hum-Lum-Rain(24h)-\r'
-        for k in _data:
-            max_c += 1
-            if max_c > max_ent:
-                break
-            _ent = self.aprs_wx_msg_pool[k][-1]
-            _td = get_timedelta_str(_ent['rx_time'])
-            _loc = f'{_ent.get("locator", "------")[:6]}({round(_ent.get("distance", -1))}km)'
-            _pres = f'{_ent["weather"].get("pressure", 0):.2f}'
-            _rain = f'{_ent["weather"].get("rain_24h", 0):.3f}'
-            out += f'{_td.rjust(9):10}{_ent.get("port_id", ""):6}{k:10}{_loc:16}'
-            out += f'{str(round(_ent["weather"].get("temperature", 0))):5}'
-            out += f'{_pres:7} '
-            out += f'{_ent["weather"].get("humidity", 0):3} '
-            out += f'{_ent["weather"].get("luminosity", 0):3} '
-            out += f'{_rain:6}\r'
-        return out
-
     #####################
     #
     @staticmethod

--- a/cli/cliMain.py
+++ b/cli/cliMain.py
@@ -95,15 +95,15 @@ class DefaultCLI(object):
             b'QUIT': (self.cmd_q, 'Quit'),
             b'BYE': (self.cmd_q, ''),
             b'CONNECT': (self.cmd_connect, 'Connect'),
+            b'ECHO': (self.cmd_echo, 'Echo'),
             b'PORT': (self.cmd_port, 'Ports'),
-            b'LCSTATUS': (self.cmd_lcstatus, STR_TABLE['cmd_help_lcstatus'][self.connection.cli_language]),
             b'MH': (self.cmd_mh, 'MYHeard List'),
             b'LMH': (self.cmd_mhl, 'Long MYHeard List'),
             b'AXIP': (self.cmd_axip, 'AXIP-MH List'),
             b'ATR': (self.cmd_aprs_trace, 'APRS-Tracer'),
             b'DXLIST': (self.cmd_dxlist, 'DX/Tracer Alarm List'),
+            b'LCSTATUS': (self.cmd_lcstatus, STR_TABLE['cmd_help_lcstatus'][self.connection.cli_language]),
             b'WX': (self.cmd_wx, 'Wetterstationen'),
-            b'ECHO': (self.cmd_echo, 'Echo'),
             b'VERSION': (self.cmd_ver, 'Version'),
             b'HELP': (self.cmd_help, STR_TABLE['help'][self.connection.cli_language]),
             b'?': (self.cmd_shelp, STR_TABLE['cmd_shelp'][self.connection.cli_language]),
@@ -119,6 +119,7 @@ class DefaultCLI(object):
             b'UMLAUT': (self.cmd_umlaut, STR_TABLE['auto_text_encoding'][self.connection.cli_language]),
             b'INFO': (self.cmd_i, 'Info'),
             b'LINFO': (self.cmd_li, 'Long Info'),
+            b'LANG': (self.cmd_lang, STR_TABLE['cli_change_language'][self.connection.cli_language]),
             b'NEWS': (self.cmd_news, 'NEWS'),
             b'POPT': (self.cmd_popt_banner, 'PoPT Banner'),
         }
@@ -467,6 +468,15 @@ class DefaultCLI(object):
         self.send_output(ret)
         self.crone_state_index = 100  # Quit State
         return ''
+
+    def cmd_lang(self):
+        if not self.parameter:
+            return f'\r # {STR_TABLE["cli_no_lang_param"][self.connection.cli_language]}{" ".join(list(constant.LANG_IND.keys()))}\r'
+        self.decode_param()
+        if self.parameter[0].upper() in constant.LANG_IND.keys():
+            self.connection.set_user_db_language(constant.LANG_IND[self.parameter[0].upper()])
+            return f'\r # {STR_TABLE["cli_lang_set"][self.connection.cli_language]}\r'
+        return f'\r # {STR_TABLE["cli_no_lang_param"][self.connection.cli_language]}{" ".join(list(constant.LANG_IND.keys()))}\r'
 
     def cmd_dxlist(self):
         parm = 10

--- a/cli/cliMain.py
+++ b/cli/cliMain.py
@@ -639,6 +639,7 @@ class DefaultCLI(object):
         out += f'Tracer Call     : {self.port_handler.aprs_ais.be_tracer_station}\r'
         out += f'Tracer WIDE Path: {self.port_handler.aprs_ais.be_tracer_wide}\r'
         out += f'Tracer intervall: {intervall_str}\r'
+        out += f'Auto Tracer     : {constant.BOOL_ON_OFF.get(self.port_handler.aprs_ais.be_auto_tracer_active, False)}\r'
         out += f'Last Trace send : {_last_send}\r\r'
         out += '-----Last-Port--Call------LOC-------------Path----------------------------------\r'
         max_c = 0

--- a/cli/cliMain.py
+++ b/cli/cliMain.py
@@ -470,9 +470,48 @@ class DefaultCLI(object):
                 parm = int(self.parameter[0])
             except ValueError:
                 pass
-        ret = MH_LIST.mh_out_cli(max_ent=parm)
+        ret = self._get_mh_out_cli(max_ent=parm)
 
         return ret + '\r'
+
+    @staticmethod
+    def _get_mh_out_cli(max_ent=20):
+        out = '\r'
+        # out += '\r                       < MH - List >\r\r'
+        c = 0
+        max_c = 0
+        """
+        tp = 0
+        tb = 0
+        rj = 0
+        """
+        sort_list = MH_LIST.get_sort_mh_entry('last', False)
+
+        for call in list(sort_list.keys()):
+            max_c += 1
+            if max_c > max_ent:
+                break
+            time_delta_str = get_timedelta_str(sort_list[call].last_seen)
+
+            out += f'{time_delta_str} P:{sort_list[call].port:4} {sort_list[call].own_call:9}'.ljust(27, " ")
+            """
+            tp += sort_list[call].pac_n
+            tb += sort_list[call].byte_n
+            rj += sort_list[call].rej_n
+            """
+            c += 1
+            if c == 2:  # Breite
+                c = 0
+                out += '\r'
+        """
+        out += '\r'
+        out += '\rTotal Packets Rec.: ' + str(tp)
+        out += '\rTotal REJ-Packets Rec.: ' + str(rj)
+        out += '\rTotal Bytes Rec.: ' + str(tb)
+        """
+        out += '\r'
+
+        return out
 
     def cmd_mhl(self):
         parm = 10
@@ -481,9 +520,58 @@ class DefaultCLI(object):
                 parm = int(self.parameter[0])
             except ValueError:
                 pass
-        ret = MH_LIST.mh_long_out_cli(max_ent=parm)
+        ret = self._get_mh_long_out_cli(max_ent=parm)
 
         return ret + '\r'
+
+    @staticmethod
+    def _get_mh_long_out_cli(max_ent=10):
+        out = '\r'
+        out += "-----Time-Port---Call------via-------LOC------Dist(km)--Type---Packets\r"
+        max_c = 0
+        """
+        tp = 0
+        tb = 0
+        rj = 0
+        """
+        sort_list = MH_LIST.get_sort_mh_entry('last', False)
+
+        for call in list(sort_list.keys()):
+            max_c += 1
+            if max_c > max_ent:
+                break
+            time_delta_str = get_timedelta_str(sort_list[call].last_seen)
+            via = sort_list[call].route
+            if via:
+                via = via[-1]
+            else:
+                via = ''
+            loc = ''
+            dis = ''
+            typ = ''
+            userdb_ent = USER_DB.get_entry(sort_list[call].own_call, add_new=False)
+            if userdb_ent:
+                loc = userdb_ent.LOC
+                if userdb_ent.Distance:
+                    dis = str(userdb_ent.Distance)
+                typ = userdb_ent.TYP
+
+            out += (f' {time_delta_str:9}{sort_list[call].port:7}{sort_list[call].own_call:10}'
+                    f'{via:10}{loc:9}{dis:10}{typ:7}{sort_list[call].pac_n}')
+            """
+            tp += sort_list[call].pac_n
+            tb += sort_list[call].byte_n
+            rj += sort_list[call].rej_n
+            """
+            out += '\r'
+        out += '\r'
+        """
+        out += '\rTotal Packets Rec.: ' + str(tp)
+        out += '\rTotal REJ-Packets Rec.: ' + str(rj)
+        out += '\rTotal Bytes Rec.: ' + str(tb)
+        out += '\r'
+        """
+        return out
 
     def cmd_wx(self):
         """ WX Stations """
@@ -495,10 +583,34 @@ class DefaultCLI(object):
                 parm = int(self.parameter[0])
             except ValueError:
                 pass
-        ret = self.port_handler.aprs_ais.get_wx_cli_out(max_ent=parm)   # TODO move CLI shit to cliMain
+        ret = self._get_wx_cli_out(max_ent=parm)
+
         if not ret:
             return f'\r # {STR_TABLE["cli_no_wx_data"][self.connection.cli_language]}\r\r'
         return ret + '\r'
+
+    def _get_wx_cli_out(self, max_ent=10):
+        _data = self.port_handler.aprs_ais.get_wx_entry_sort_distance()
+        if not _data:
+            return ''
+        max_c = 0
+        out = '\r-----Last-Port--Call------LOC-------------Temp-Press---Hum-Lum-Rain(24h)-\r'
+        for k in _data:
+            max_c += 1
+            if max_c > max_ent:
+                break
+            _ent = self.port_handler.aprs_ais.aprs_wx_msg_pool[k][-1]
+            _td = get_timedelta_str(_ent['rx_time'])
+            _loc = f'{_ent.get("locator", "------")[:6]}({round(_ent.get("distance", -1))}km)'
+            _pres = f'{_ent["weather"].get("pressure", 0):.2f}'
+            _rain = f'{_ent["weather"].get("rain_24h", 0):.3f}'
+            out += f'{_td.rjust(9):10}{_ent.get("port_id", ""):6}{k:10}{_loc:16}'
+            out += f'{str(round(_ent["weather"].get("temperature", 0))):5}'
+            out += f'{_pres:7} '
+            out += f'{_ent["weather"].get("humidity", 0):3} '
+            out += f'{_ent["weather"].get("luminosity", 0):3} '
+            out += f'{_rain:6}\r'
+        return out
 
     def cmd_aprs_trace(self):
         """APRS Tracer"""

--- a/cli/cliMain.py
+++ b/cli/cliMain.py
@@ -481,13 +481,13 @@ class DefaultCLI(object):
         max_c = 0
         out = '\r'
         # out += '\r                       < AXIP - Clients >\r\r'
-        out += '-Call-----IP:Port---------------------------Last------------\r'
+        out += '-Call------IP:Port---------------------------Last------------\r'
         for k in _ent.keys():
             if _ent[k].axip_add[0]:
                 max_c += 1
                 if max_c > max_ent:
                     break
-                out += '{:9} {:33} {:8}\r'.format(
+                out += ' {:9} {:33} {:8}\r'.format(
                     _ent[k].own_call,
                     _ent[k].axip_add[0] + ':' + str(_ent[k].axip_add[1]),
                     get_timedelta_str(_ent[k].last_seen, r_just=False)

--- a/cli/cliMain.py
+++ b/cli/cliMain.py
@@ -521,9 +521,10 @@ class DefaultCLI(object):
             intervall_str = 'off'
         else:
             intervall_str = str(_intervall)
-        out = '\r # APRS-Tracer Beacon\r\r'
-        out += f'Tracer Call     : {self.port_handler.aprs_ais.be_tracer_port}\r'
-        out += f'Tracer Port     : {self.port_handler.aprs_ais.be_tracer_station}\r'
+        # out = '\r # APRS-Tracer Beacon\r\r'
+        out = '\r'
+        out += f'Tracer Port     : {self.port_handler.aprs_ais.be_tracer_port}\r'
+        out += f'Tracer Call     : {self.port_handler.aprs_ais.be_tracer_station}\r'
         out += f'Tracer WIDE Path: {self.port_handler.aprs_ais.be_tracer_wide}\r'
         out += f'Tracer intervall: {intervall_str}\r'
         out += f'Last Trace send : {_last_send}\r\r'
@@ -538,9 +539,18 @@ class DefaultCLI(object):
             _path = ', '.join(_ent.get('path', []))
             _loc = f'{_ent.get("locator", "------")[:6]}({round(_ent.get("distance", -1))}km)'
             _call = _ent.get('call', '')
-            _path = ', '.join(_ent.get('path', []))
+            _path_raw = _ent.get('path', [])
+            _path = ''
+            _c = 0
+            for _el in _path_raw:
+                _path += f'{_el}> '
+                _c += 1
+                if _c == 3:
+                    _path += '\r' + ''.rjust(42, ' ')
+                    _c = 0
+
             out += f'{_td.rjust(9):10}{_ent.get("port_id", "-"):6}{_call:10}{_loc:16}'
-            out += f'{_path}'
+            out += f'{_path[:-2]}'
             out += '\r'
 
         return out + '\r'

--- a/cli/cliMain.py
+++ b/cli/cliMain.py
@@ -98,6 +98,7 @@ class DefaultCLI(object):
             b'PORT': (self.cmd_port, 'Ports'),
             b'LCSTATUS': (self.cmd_lcstatus, STR_TABLE['cmd_help_lcstatus'][self.connection.cli_language]),
             b'MH': (self.cmd_mh, 'MYHeard Liste'),
+            b'AXIP': (self.cmd_axip, 'AXIP-MH Liste'),
             b'LMH': (self.cmd_mhl, 'Long MYHeard Liste'),
             b'ATR': (self.cmd_aprs_trace, 'APRS-Tracer'),
             b'WX': (self.cmd_wx, 'Wetterstationen'),
@@ -462,6 +463,36 @@ class DefaultCLI(object):
         self.send_output(ret)
         self.crone_state_index = 100  # Quit State
         return ''
+
+    def cmd_axip(self):
+        parm = 10
+        if self.parameter:
+            try:
+                parm = int(self.parameter[0])
+            except ValueError:
+                pass
+        ret = self._get_axip_out_cli(max_ent=parm)
+
+        return ret + '\r'
+
+    @staticmethod
+    def _get_axip_out_cli(max_ent=10):
+        _ent = MH_LIST.get_sort_mh_entry('last', reverse=False)
+        max_c = 0
+        out = '\r'
+        # out += '\r                       < AXIP - Clients >\r\r'
+        out += '-Call-----IP:Port------------------------Last---------------\r'
+        for k in _ent.keys():
+            if _ent[k].axip_add[0]:
+                max_c += 1
+                if max_c > max_ent:
+                    break
+                out += '{:9} {:30} {:8}\r'.format(
+                    _ent[k].own_call,
+                    _ent[k].axip_add[0] + ':' + str(_ent[k].axip_add[1]),
+                    get_timedelta_str(_ent[k].last_seen, r_just=False)
+                )
+        return out
 
     def cmd_mh(self):
         parm = 20

--- a/cli/cliMain.py
+++ b/cli/cliMain.py
@@ -93,7 +93,7 @@ class DefaultCLI(object):
         # Standard Commands ( GLOBAL )
         self.commands = {
             b'QUIT': (self.cmd_q, 'Quit'),
-            b'BYE': (self.cmd_q, ''),
+            b'BYE': (self.cmd_q, 'Bye'),
             b'CONNECT': (self.cmd_connect, 'Connect'),
             b'ECHO': (self.cmd_echo, 'Echo'),
             b'PORT': (self.cmd_port, 'Ports'),
@@ -104,24 +104,25 @@ class DefaultCLI(object):
             b'DXLIST': (self.cmd_dxlist, 'DX/Tracer Alarm List'),
             b'LCSTATUS': (self.cmd_lcstatus, STR_TABLE['cmd_help_lcstatus'][self.connection.cli_language]),
             b'WX': (self.cmd_wx, 'Wetterstationen'),
+
+            b'INFO': (self.cmd_i, 'Info'),
+            b'LINFO': (self.cmd_li, 'Long Info'),
+            b'NEWS': (self.cmd_news, 'NEWS'),
             b'VERSION': (self.cmd_ver, 'Version'),
+            b'USER': (self.cmd_user_db_detail, STR_TABLE['cmd_help_user_db'][self.connection.cli_language]),
+            b'DBNAME': (self.cmd_set_name, STR_TABLE['cmd_help_set_name'][self.connection.cli_language]),
+            b'DBQTH': (self.cmd_set_qth, STR_TABLE['cmd_help_set_qth'][self.connection.cli_language]),
+            b'DBLOC': (self.cmd_set_loc, STR_TABLE['cmd_help_set_loc'][self.connection.cli_language]),
+            b'DBZIP': (self.cmd_set_zip, STR_TABLE['cmd_help_set_zip'][self.connection.cli_language]),
+            b'DBPRMAIL': (self.cmd_set_pr_mail, STR_TABLE['cmd_help_set_prmail'][self.connection.cli_language]),
+            b'DBEMAIL': (self.cmd_set_e_mail, STR_TABLE['cmd_help_set_email'][self.connection.cli_language]),
+            b'DBWEB': (self.cmd_set_http, STR_TABLE['cmd_help_set_http'][self.connection.cli_language]),
+            b'LANG': (self.cmd_lang, STR_TABLE['cli_change_language'][self.connection.cli_language]),
+            b'UMLAUT': (self.cmd_umlaut, STR_TABLE['auto_text_encoding'][self.connection.cli_language]),
+            b'POPT': (self.cmd_popt_banner, 'PoPT Banner'),
             b'HELP': (self.cmd_help, STR_TABLE['help'][self.connection.cli_language]),
             b'?': (self.cmd_shelp, STR_TABLE['cmd_shelp'][self.connection.cli_language]),
 
-            b'NAME': (self.cmd_set_name, STR_TABLE['cmd_help_set_name'][self.connection.cli_language]),
-            b'QTH': (self.cmd_set_qth, STR_TABLE['cmd_help_set_qth'][self.connection.cli_language]),
-            b'LOC': (self.cmd_set_loc, STR_TABLE['cmd_help_set_loc'][self.connection.cli_language]),
-            b'ZIP': (self.cmd_set_zip, STR_TABLE['cmd_help_set_zip'][self.connection.cli_language]),
-            b'PRMAIL': (self.cmd_set_pr_mail, STR_TABLE['cmd_help_set_prmail'][self.connection.cli_language]),
-            b'EMAIL': (self.cmd_set_e_mail, STR_TABLE['cmd_help_set_email'][self.connection.cli_language]),
-            b'WEB': (self.cmd_set_http, STR_TABLE['cmd_help_set_http'][self.connection.cli_language]),
-            b'USER': (self.cmd_user_db_detail, STR_TABLE['cmd_help_user_db'][self.connection.cli_language]),
-            b'UMLAUT': (self.cmd_umlaut, STR_TABLE['auto_text_encoding'][self.connection.cli_language]),
-            b'INFO': (self.cmd_i, 'Info'),
-            b'LINFO': (self.cmd_li, 'Long Info'),
-            b'LANG': (self.cmd_lang, STR_TABLE['cli_change_language'][self.connection.cli_language]),
-            b'NEWS': (self.cmd_news, 'NEWS'),
-            b'POPT': (self.cmd_popt_banner, 'PoPT Banner'),
         }
 
         self.str_cmd_exec = {
@@ -1078,7 +1079,8 @@ class DefaultCLI(object):
         return ret
 
     def cmd_help(self):
-        ret = f"\r   < {STR_TABLE['help'][self.connection.cli_language]} >\r"
+        # ret = f"\r   < {STR_TABLE['help'][self.connection.cli_language]} >\r"
+        ret = "\r"
         """
         c = 1
         new_cmd = {}

--- a/cli/cliMain.py
+++ b/cli/cliMain.py
@@ -523,8 +523,10 @@ class DefaultCLI(object):
             if max_c > max_ent:
                 break
             time_delta_str = get_timedelta_str(sort_list[call].last_seen)
-
-            out += f'{time_delta_str} P:{sort_list[call].port:4} {sort_list[call].own_call:9}'.ljust(27, " ")
+            _call_str = sort_list[call].own_call
+            if sort_list[call].route:
+                _call_str += '*'
+            out += f'{time_delta_str} P:{sort_list[call].port:4} {_call_str:10}'.ljust(27, " ")
             """
             tp += sort_list[call].pac_n
             tb += sort_list[call].byte_n

--- a/constant.py
+++ b/constant.py
@@ -3,13 +3,19 @@ TODO IDEA:
 https://stackoverflow.com/questions/2682745/how-do-i-create-a-constant-in-python
 """
 
-VER = '2.98.13dev'
+VER = '2.98.14dev'
 LANGUAGE = 0  # QUICK FIX
 """
 0 = German
 1 = English
 2 = Dutch
 """
+LANG_IND = {
+            'DE': 0,
+            'EN': 1,
+            'NL': 2,
+        }
+
 CFG_data_path = 'data/'
 CFG_usertxt_path = 'userdata/'
 CFG_ft_downloads = 'ft_downloads/'

--- a/constant.py
+++ b/constant.py
@@ -3,7 +3,7 @@ TODO IDEA:
 https://stackoverflow.com/questions/2682745/how-do-i-create-a-constant-in-python
 """
 
-VER = '2.98.10dev'
+VER = '2.98.11dev'
 LANGUAGE = 0  # QUICK FIX
 """
 0 = German

--- a/constant.py
+++ b/constant.py
@@ -3,7 +3,7 @@ TODO IDEA:
 https://stackoverflow.com/questions/2682745/how-do-i-create-a-constant-in-python
 """
 
-VER = '2.98.9dev'
+VER = '2.98.10dev'
 LANGUAGE = 0  # QUICK FIX
 """
 0 = German

--- a/constant.py
+++ b/constant.py
@@ -3,7 +3,7 @@ TODO IDEA:
 https://stackoverflow.com/questions/2682745/how-do-i-create-a-constant-in-python
 """
 
-VER = '2.98.5dev'
+VER = '2.98.6dev'
 LANGUAGE = 0  # QUICK FIX
 """
 0 = German
@@ -175,4 +175,9 @@ STATUS_BG = {
     'RNR-REJ': 'light sky blue',  # 14
     'DEST-RNR-REJ': 'sky blue',  # 15
     'BOTH-RNR-REJ': 'deep sky blue',  # 16
+}
+
+BOOL_ON_OFF = {
+    True: 'ON',
+    False: 'OFF',
 }

--- a/constant.py
+++ b/constant.py
@@ -3,7 +3,7 @@ TODO IDEA:
 https://stackoverflow.com/questions/2682745/how-do-i-create-a-constant-in-python
 """
 
-VER = '2.98.0dev'
+VER = '2.98.1dev'
 LANGUAGE = 0  # QUICK FIX
 """
 0 = German

--- a/constant.py
+++ b/constant.py
@@ -3,7 +3,7 @@ TODO IDEA:
 https://stackoverflow.com/questions/2682745/how-do-i-create-a-constant-in-python
 """
 
-VER = '2.97.9'
+VER = '2.98.0dev'
 LANGUAGE = 0  # QUICK FIX
 """
 0 = German

--- a/constant.py
+++ b/constant.py
@@ -3,7 +3,7 @@ TODO IDEA:
 https://stackoverflow.com/questions/2682745/how-do-i-create-a-constant-in-python
 """
 
-VER = '2.98.2dev'
+VER = '2.98.3dev'
 LANGUAGE = 0  # QUICK FIX
 """
 0 = German

--- a/constant.py
+++ b/constant.py
@@ -3,7 +3,7 @@ TODO IDEA:
 https://stackoverflow.com/questions/2682745/how-do-i-create-a-constant-in-python
 """
 
-VER = '2.98.12dev'
+VER = '2.98.13dev'
 LANGUAGE = 0  # QUICK FIX
 """
 0 = German
@@ -124,6 +124,7 @@ STAT_BAR_TXT_CLR = 'black'
 FONT_STAT_BAR = 'Arial'
 PARAM_MAX_MON_LEN = 100000
 CFG_clr_sys_msg = 'red'
+CFG_TR_DX_ALARM_BG_CLR = '#55ed9f'
 
 
 POPT_BANNER = '\r$$$$$$$\   $$$$$$\     $$$$$$$\ $$$$$$$$|\r' \

--- a/constant.py
+++ b/constant.py
@@ -3,7 +3,7 @@ TODO IDEA:
 https://stackoverflow.com/questions/2682745/how-do-i-create-a-constant-in-python
 """
 
-VER = '2.98.8dev'
+VER = '2.98.9dev'
 LANGUAGE = 0  # QUICK FIX
 """
 0 = German

--- a/constant.py
+++ b/constant.py
@@ -3,7 +3,7 @@ TODO IDEA:
 https://stackoverflow.com/questions/2682745/how-do-i-create-a-constant-in-python
 """
 
-VER = '2.98.1dev'
+VER = '2.98.2dev'
 LANGUAGE = 0  # QUICK FIX
 """
 0 = German

--- a/constant.py
+++ b/constant.py
@@ -3,7 +3,7 @@ TODO IDEA:
 https://stackoverflow.com/questions/2682745/how-do-i-create-a-constant-in-python
 """
 
-VER = '2.98.3dev'
+VER = '2.98.4dev'
 LANGUAGE = 0  # QUICK FIX
 """
 0 = German

--- a/constant.py
+++ b/constant.py
@@ -3,7 +3,7 @@ TODO IDEA:
 https://stackoverflow.com/questions/2682745/how-do-i-create-a-constant-in-python
 """
 
-VER = '2.98.4dev'
+VER = '2.98.5dev'
 LANGUAGE = 0  # QUICK FIX
 """
 0 = German
@@ -17,6 +17,9 @@ CFG_user_db = 'data/UserDB.popt'
 CFG_mh_data_file = 'data/mh_data.popt'
 CFG_port_stat_data_file = 'data/port_stat.popt'
 CFG_aprs_data_file = 'aprs.popt'
+CFG_sound_DICO = '//data//sound//disco_alarm.wav'
+CFG_sound_CONN = '//data//sound//conn_alarm.wav'
+CFG_sound_RX_BEEP = '//data//sound//rx_beep.wav'
 
 CFG_txt_save = {
     'stat_parm_cli_ctext': 'ctx',

--- a/constant.py
+++ b/constant.py
@@ -3,7 +3,7 @@ TODO IDEA:
 https://stackoverflow.com/questions/2682745/how-do-i-create-a-constant-in-python
 """
 
-VER = '2.98.7dev'
+VER = '2.98.8dev'
 LANGUAGE = 0  # QUICK FIX
 """
 0 = German

--- a/constant.py
+++ b/constant.py
@@ -3,7 +3,7 @@ TODO IDEA:
 https://stackoverflow.com/questions/2682745/how-do-i-create-a-constant-in-python
 """
 
-VER = '2.98.14dev'
+VER = '2.98.15'
 LANGUAGE = 0  # QUICK FIX
 """
 0 = German

--- a/constant.py
+++ b/constant.py
@@ -3,7 +3,7 @@ TODO IDEA:
 https://stackoverflow.com/questions/2682745/how-do-i-create-a-constant-in-python
 """
 
-VER = '2.98.11dev'
+VER = '2.98.12dev'
 LANGUAGE = 0  # QUICK FIX
 """
 0 = German

--- a/constant.py
+++ b/constant.py
@@ -3,7 +3,7 @@ TODO IDEA:
 https://stackoverflow.com/questions/2682745/how-do-i-create-a-constant-in-python
 """
 
-VER = '2.98.6dev'
+VER = '2.98.7dev'
 LANGUAGE = 0  # QUICK FIX
 """
 0 = German

--- a/fnc/str_fnc.py
+++ b/fnc/str_fnc.py
@@ -31,6 +31,10 @@ def conv_time_for_sorting(dateti: datetime.now()):
     return dateti.strftime('%y/%m/%d %H:%M:%S')
 
 
+def conv_time_for_key(dateti: datetime.now()):
+    return dateti.strftime('%y%m%d%H%M%S')
+
+
 def conv_time_US_str(dateti: datetime.now()):
     return dateti.strftime('%m/%d/%y %H:%M:%S')
 

--- a/fnc/str_fnc.py
+++ b/fnc/str_fnc.py
@@ -116,7 +116,6 @@ def convert_str_to_datetime(date_str, date_format='%d/%m/%y %H:%M:%S'):
     except ValueError:
         return 0
 
-
 def conv_timestamp_delta(delta):
     if delta:
         timestamp = str(delta)

--- a/fnc/str_fnc.py
+++ b/fnc/str_fnc.py
@@ -43,7 +43,7 @@ def get_file_timestamp():
     return datetime.now().strftime('%d%m/%y-%H%M')
 
 
-def get_timedelta_str(dateti: datetime.now()):
+def get_timedelta_str(dateti: datetime.now(), r_just=True):
     _time_delta = datetime.now() - dateti
     _td_days = _time_delta.days
     _td_hours = int(_time_delta.seconds / 3600)
@@ -52,15 +52,27 @@ def get_timedelta_str(dateti: datetime.now()):
 
     if _td_days:
         # td_hours = td_hours - td_days * 24
-        _time_delta_str = f'{str(_td_days).rjust(3, " ")}d,{str(_td_hours).rjust(2, " ")}h'
+        if r_just:
+            _time_delta_str = f'{str(_td_days).rjust(3, " ")}d,{str(_td_hours).rjust(2, " ")}h'
+        else:
+            _time_delta_str = f'{_td_days}d,{_td_hours}h'
     elif _td_hours:
         _td_min = _td_min - _td_hours * 60
-        _time_delta_str = f'{str(_td_hours).rjust(3, " ")}h,{str(_td_min).rjust(2, " ")}m'
+        if r_just:
+            _time_delta_str = f'{str(_td_hours).rjust(3, " ")}h,{str(_td_min).rjust(2, " ")}m'
+        else:
+            _time_delta_str = f'{_td_hours}h,{_td_min}m'
     elif _td_min:
         _td_sec = _td_sec - _td_min * 60
-        _time_delta_str = f'{str(_td_min).rjust(3, " ")}m,{str(_td_sec).rjust(2, " ")}s'
+        if r_just:
+            _time_delta_str = f'{str(_td_min).rjust(3, " ")}m,{str(_td_sec).rjust(2, " ")}s'
+        else:
+            _time_delta_str = f'{_td_min}m,{_td_sec}s'
     else:
-        _time_delta_str = f'{str(_td_sec).rjust(7, " ")}s'
+        if r_just:
+            _time_delta_str = f'{str(_td_sec).rjust(7, " ")}s'
+        else:
+            _time_delta_str = f'{_td_sec}s'
     return _time_delta_str
 
 

--- a/fnc/struct_fnc.py
+++ b/fnc/struct_fnc.py
@@ -1,0 +1,65 @@
+from datetime import datetime
+
+from fnc.str_fnc import conv_time_for_key
+
+
+def get_dx_tx_alarm_his_pack(
+        port_id: int,
+        call_str: str,
+        via: str,
+        path: list,
+        locator: str,
+        distance: float,
+        typ: str,
+):
+    _now = datetime.now()
+    return {
+        'ts': _now,
+        'port_id': port_id,
+        'call_str': call_str,
+        'via': via,
+        'path': path,
+        'loc': locator,
+        'dist': distance,
+        'typ': typ,
+        'key': f"{conv_time_for_key(_now)}{call_str}",
+
+    }
+
+
+def get_bandwidth_struct():
+    _struct = {}
+    for _h in range(24):
+        for _m in range(60):
+            for _s in range(6):
+                _ts_str = f'{str(_h).zfill(2)}:{str(_m).zfill(2)}:{_s}'
+                _struct[_ts_str] = 0
+    return _struct
+
+
+def get_port_stat_struct():
+    struct_hour = {}
+    for key in [
+        'N_pack',
+        'I',
+        'SABM',
+        'DM',
+        'DISC',
+        'REJ',
+        'RR',
+        'RNR',
+        'UI',
+        'FRMR',
+        'DATA_W_HEADER',
+        'DATA'
+    ]:
+        struct_hour[key] = {minute: 0 for minute in range(60)}
+    return struct_hour
+
+
+def init_day_dic():
+
+    ret = {}
+    for hour in range(24):
+        ret[hour] = get_port_stat_struct()
+    return ret

--- a/gui/guiAPRS_be_tracer.py
+++ b/gui/guiAPRS_be_tracer.py
@@ -283,9 +283,7 @@ class BeaconTracer(tk.Toplevel):
 
     def _chk_active(self, event=None):
         self._save_vars()
-        _root_gui = PORT_HANDLER.get_root_gui()
-        if _root_gui is not None:
-            _root_gui.tabbed_sideFrame.set_tracer_chk(PORT_HANDLER.get_aprs_ais().be_tracer_active)
+        self._root_win.set_tracer_fm_aprs()
 
     def close(self):
         self._root_win.be_tracer_win = None

--- a/gui/guiAPRS_be_tracer.py
+++ b/gui/guiAPRS_be_tracer.py
@@ -212,8 +212,12 @@ class BeaconTracer(tk.Toplevel):
     def _update_tree(self):
         for i in self._tree.get_children():
             self._tree.delete(i)
+        self._tree.tag_configure("tr_alarm", background='#55ed9f', foreground='black')
         for ret_ent in self._tree_data:
-            self._tree.insert('', tk.END, values=ret_ent)
+            if ret_ent[1]:
+                self._tree.insert('', tk.END, values=ret_ent[0], tags=('tr_alarm',))
+            else:
+                self._tree.insert('', tk.END, values=ret_ent[0], )
 
     def _format_tree_data(self):
         _traces = PORT_HANDLER.get_aprs_ais().tracer_traces_get()
@@ -232,7 +236,7 @@ class BeaconTracer(tk.Toplevel):
                 _loc = _pack.get('locator', '')
                 _dist = _pack.get('distance', 0)
 
-                self._tree_data.append((
+                self._tree_data.append(((
                     _rx_time,
                     _call,
                     _port_id,
@@ -240,7 +244,8 @@ class BeaconTracer(tk.Toplevel):
                     f'{_rtt:.2f}',
                     _loc,
                     _dist,
-                ))
+                ), _pack.get('tr_alarm', False)))
+                _pack['tr_alarm'] = False
 
     def _save_btn(self):
         self._save_vars()

--- a/gui/guiAPRS_be_tracer.py
+++ b/gui/guiAPRS_be_tracer.py
@@ -3,6 +3,7 @@ import tkinter as tk
 from tkinter import ttk
 
 from ax25.ax25InitPorts import PORT_HANDLER
+from constant import CFG_TR_DX_ALARM_BG_CLR
 
 logger = logging.getLogger(__name__)
 
@@ -212,7 +213,7 @@ class BeaconTracer(tk.Toplevel):
     def _update_tree(self):
         for i in self._tree.get_children():
             self._tree.delete(i)
-        self._tree.tag_configure("tr_alarm", background='#55ed9f', foreground='black')
+        self._tree.tag_configure("tr_alarm", background=CFG_TR_DX_ALARM_BG_CLR, foreground='black')
         for ret_ent in self._tree_data:
             if ret_ent[1]:
                 self._tree.insert('', tk.END, values=ret_ent[0], tags=('tr_alarm',))

--- a/gui/guiAPRS_wx_plot.py
+++ b/gui/guiAPRS_wx_plot.py
@@ -6,9 +6,6 @@ from matplotlib.backends._backend_tk import NavigationToolbar2Tk
 from matplotlib.figure import Figure
 from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg
 
-from fnc.loc_fnc import coordinates_to_locator
-from fnc.str_fnc import convert_str_to_datetime
-
 
 def adjust_list_len(target_list: list, compare_list: list):
     if len(target_list) < len(compare_list):

--- a/gui/guiAPRS_wx_tree.py
+++ b/gui/guiAPRS_wx_tree.py
@@ -3,7 +3,6 @@ import tkinter as tk
 from tkinter import ttk
 
 from ax25.ax25InitPorts import PORT_HANDLER
-from fnc.loc_fnc import coordinates_to_locator, locator_distance
 from gui.guiAPRS_wx_plot import WXPlotWindow
 
 logger = logging.getLogger(__name__)

--- a/gui/guiMH.py
+++ b/gui/guiMH.py
@@ -34,11 +34,11 @@ class MHWin(tk.Toplevel):
         ###################################
         # Vars
         self._rev_ent = False
-        self._alarm_active_var = tk.BooleanVar(self)
+        # self._alarm_active_var = self._root_win.setting_dx_alarm
         self._alarm_newCall_var = tk.BooleanVar(self)
         self._alarm_seenSince_var = tk.StringVar(self)
         self._alarm_distance_var = tk.StringVar(self)
-        self._tracer_active_var = tk.BooleanVar(self)
+        # self._tracer_active_var = tk.BooleanVar(self)
         self._tracer_duration_var = tk.StringVar(self)
         self._get_vars()
         # ############################### Columns ############################
@@ -60,7 +60,7 @@ class MHWin(tk.Toplevel):
 
         tk.Label(frame_21_active, text='Activate ').pack(side=tk.LEFT, )
         tk.Checkbutton(frame_21_active,
-                       variable=self._alarm_active_var,
+                       variable=self._root_win.setting_dx_alarm,
                        # command=self._chk_alarm_active
                        ).pack(side=tk.LEFT, )
 
@@ -104,6 +104,10 @@ class MHWin(tk.Toplevel):
 
         # ###################### Auto Tracer ######################
         # Tracer
+        _auto_tracer_state = {
+            True: 'disabled',
+            False: 'normal'
+        }.get(self._root_win.get_tracer(), 'disabled')
         lower_frame_tracer = tk.Frame(self)
         lower_frame_tracer.grid(row=1, column=0, columnspan=2, sticky='nsew')
         frame_12_label = tk.Frame(lower_frame_tracer)
@@ -116,8 +120,9 @@ class MHWin(tk.Toplevel):
 
         tk.Label(frame_22_active, text='Activate ').pack(side=tk.LEFT, )
         tk.Checkbutton(frame_22_active,
-                       variable=self._tracer_active_var,
-                       # command=self._chk_alarm_active
+                       variable=self._root_win.setting_auto_tracer,
+                       command=self._root_win.set_auto_tracer,
+                       state=_auto_tracer_state
                        ).pack(side=tk.LEFT, )
         # duration
         frame_22_duration = tk.Frame(lower_frame_tracer)
@@ -130,6 +135,7 @@ class MHWin(tk.Toplevel):
                    increment=5,
                    width=5,
                    textvariable=self._tracer_duration_var,
+                   state=_auto_tracer_state
                    # command=self._set_alarm_distance
                    ).pack(side=tk.LEFT, )
 
@@ -137,7 +143,7 @@ class MHWin(tk.Toplevel):
         # TREE
         columns = (
             'mh_last_seen',
-            'mh_first_seen' ,
+            'mh_first_seen',
             'mh_port',
             'mh_call',
             'mh_loc',
@@ -184,11 +190,11 @@ class MHWin(tk.Toplevel):
         self._tree.bind('<<TreeviewSelect>>', self.entry_selected)
 
     def _get_vars(self):
-        self._alarm_active_var.set(bool())
+        # self._alarm_active_var.set(bool())
         self._alarm_newCall_var.set(bool())
         self._alarm_seenSince_var.set(str())
         self._alarm_distance_var.set(str())
-        self._tracer_active_var.set(bool())
+        # self._tracer_active_var.set(bool(self._root_win.setting_auto_tracer.get()))
         self._tracer_duration_var.set(str())
 
     def entry_selected(self, event):

--- a/gui/guiMH.py
+++ b/gui/guiMH.py
@@ -1,6 +1,5 @@
 import logging
 import tkinter as tk
-from tkinter import Menu
 from tkinter import ttk
 
 from ax25.ax25InitPorts import PORT_HANDLER
@@ -240,7 +239,6 @@ class MHWin(tk.Toplevel):
                 if _i in MH_LIST.parm_alarm_ports:
                     MH_LIST.parm_alarm_ports.remove(int(_i))
             _i += 1
-        print(MH_LIST.parm_alarm_ports)
 
     def _set_alarm_distance(self, event=None):
         _var = self._alarm_distance_var.get()
@@ -315,9 +313,6 @@ class MHWin(tk.Toplevel):
                 axip_str = '{} - {}'.format(ent.axip_add[0], ent.axip_add[1])
             else:
                 axip_str = ''
-            route = ''
-            if ent.all_routes:
-                route = min(ent.all_routes)
 
             self._tree_data.append((
                 f'{conv_time_DE_str(ent.last_seen)}',
@@ -328,7 +323,7 @@ class MHWin(tk.Toplevel):
                 f'{ent.distance}',
                 f'{ent.pac_n}',
                 f'{ent.rej_n}',
-                ' '.join(route),
+                ' '.join(ent.route),
                 f'{axip_str}',
                 f'{ent.axip_fail}',
             ))

--- a/gui/guiMH.py
+++ b/gui/guiMH.py
@@ -135,8 +135,8 @@ class MHWin(tk.Toplevel):
                    increment=5,
                    width=5,
                    textvariable=self._tracer_duration_var,
-                   state=_auto_tracer_state
-                   # command=self._set_alarm_distance
+                   state=_auto_tracer_state,
+                   command=self._set_auto_tracer,
                    ).pack(side=tk.LEFT, )
 
         ##########################################################################################
@@ -195,7 +195,7 @@ class MHWin(tk.Toplevel):
         self._alarm_seenSince_var.set(str(MH_LIST.parm_lastseen_alarm))
         self._alarm_distance_var.set(str(MH_LIST.parm_distance_alarm))
         # self._tracer_active_var.set(bool(self._root_win.setting_auto_tracer.get()))
-        self._tracer_duration_var.set(str())
+        self._tracer_duration_var.set(str(self._root_win.get_auto_tracer_duration()))
 
     def _set_alarm_distance(self, event=None):
         _var = self._alarm_distance_var.get()
@@ -215,6 +215,14 @@ class MHWin(tk.Toplevel):
 
     def _set_alarm_newCall(self, event=None):
         MH_LIST.parm_new_call_alarm = bool(self._alarm_newCall_var.get())
+
+    def _set_auto_tracer(self, event=None):
+        _dur = self._tracer_duration_var.get()
+        try:
+            _dur = int(_dur)
+        except ValueError:
+            return
+        self._root_win.set_auto_tracer_duration(_dur)
 
     def entry_selected(self, event):
         for selected_item in self._tree.selection():

--- a/gui/guiMH.py
+++ b/gui/guiMH.py
@@ -292,8 +292,12 @@ class MHWin(tk.Toplevel):
     def _update_tree(self):
         for i in self._tree.get_children():
             self._tree.delete(i)
+        self._tree.tag_configure("dx_alarm", background='#55ed9f', foreground='black')
         for ret_ent in self._tree_data:
-            self._tree.insert('', tk.END, values=ret_ent)
+            if ret_ent[1]:
+                self._tree.insert('', tk.END, values=ret_ent[0], tags=('dx_alarm',))
+            else:
+                self._tree.insert('', tk.END, values=ret_ent[0], )
 
     def _sort_entry(self, flag: str):
         sort_date = MH_LIST.get_sort_mh_entry(flag_str=flag, reverse=self._rev_ent)
@@ -313,8 +317,11 @@ class MHWin(tk.Toplevel):
                 axip_str = '{} - {}'.format(ent.axip_add[0], ent.axip_add[1])
             else:
                 axip_str = ''
+            _dx_alarm = False
+            if ent.own_call in list(MH_LIST.dx_alarm_hist):
+                _dx_alarm = True
 
-            self._tree_data.append((
+            self._tree_data.append(((
                 f'{conv_time_DE_str(ent.last_seen)}',
                 f'{conv_time_DE_str(ent.first_seen)}',
                 f'{ent.port_id} {ent.port}',
@@ -326,12 +333,13 @@ class MHWin(tk.Toplevel):
                 ' '.join(ent.route),
                 f'{axip_str}',
                 f'{ent.axip_fail}',
-            ))
+            ), _dx_alarm))
 
     def __del__(self):
         self._root_win.mh_window = None
         # self.destroy()
 
     def close(self):
+        MH_LIST.reset_dx_alarm_his()
         self._root_win.mh_window = None
         self.destroy()

--- a/gui/guiMH.py
+++ b/gui/guiMH.py
@@ -4,6 +4,7 @@ from tkinter import ttk
 
 from ax25.ax25InitPorts import PORT_HANDLER
 from ax25.ax25Statistics import MyHeard, MH_LIST
+from constant import CFG_TR_DX_ALARM_BG_CLR
 from fnc.str_fnc import conv_time_DE_str
 
 logger = logging.getLogger(__name__)
@@ -292,7 +293,7 @@ class MHWin(tk.Toplevel):
     def _update_tree(self):
         for i in self._tree.get_children():
             self._tree.delete(i)
-        self._tree.tag_configure("dx_alarm", background='#55ed9f', foreground='black')
+        self._tree.tag_configure("dx_alarm", background=CFG_TR_DX_ALARM_BG_CLR, foreground='black')
         for ret_ent in self._tree_data:
             if ret_ent[1]:
                 self._tree.insert('', tk.END, values=ret_ent[0], tags=('dx_alarm',))

--- a/gui/guiMH.py
+++ b/gui/guiMH.py
@@ -71,35 +71,35 @@ class MHWin(tk.Toplevel):
         tk.Label(frame_21_newCall, text='new Call ').pack(side=tk.LEFT, )
         tk.Checkbutton(frame_21_newCall,
                        variable=self._alarm_newCall_var,
-                       # command=self._chk_alarm_active
+                       command=self._set_alarm_newCall
                        ).pack(side=tk.LEFT, )
 
         # Alarm seen since Days
         frame_21_seen = tk.Frame(lower_frame)
         frame_21_seen.pack(side=tk.LEFT, fill=tk.BOTH, padx=30)
 
-        tk.Label(frame_21_seen, text='seen since (Days) ').pack(side=tk.LEFT, )
+        tk.Label(frame_21_seen, text='seen since (Days) (0 = off)').pack(side=tk.LEFT, )
         tk.Spinbox(frame_21_seen,
                    from_=1,
                    to=365,
-                   increment=10,
+                   increment=1,
                    width=4,
                    textvariable=self._alarm_seenSince_var,
-                   # command=self._set_alarm_distance
+                   command=self._set_alarm_last_seen
                    ).pack(side=tk.LEFT, )
 
         # Alarm Distance
         frame_21_distance = tk.Frame(lower_frame)
         frame_21_distance.pack(side=tk.LEFT, fill=tk.BOTH, padx=30)
 
-        tk.Label(frame_21_distance, text='Distance ').pack(side=tk.LEFT, )
+        tk.Label(frame_21_distance, text='Distance (0 = off)').pack(side=tk.LEFT, )
         tk.Spinbox(frame_21_distance,
-                   from_=1,
+                   from_=0,
                    to=20000,
-                   increment=50,
+                   increment=1,
                    width=6,
                    textvariable=self._alarm_distance_var,
-                   # command=self._set_alarm_distance
+                   command=self._set_alarm_distance
                    ).pack(side=tk.LEFT, )
 
         # ###################### Auto Tracer ######################
@@ -191,11 +191,30 @@ class MHWin(tk.Toplevel):
 
     def _get_vars(self):
         # self._alarm_active_var.set(bool())
-        self._alarm_newCall_var.set(bool())
-        self._alarm_seenSince_var.set(str())
-        self._alarm_distance_var.set(str())
+        self._alarm_newCall_var.set(bool(MH_LIST.parm_new_call_alarm))
+        self._alarm_seenSince_var.set(str(MH_LIST.parm_lastseen_alarm))
+        self._alarm_distance_var.set(str(MH_LIST.parm_distance_alarm))
         # self._tracer_active_var.set(bool(self._root_win.setting_auto_tracer.get()))
         self._tracer_duration_var.set(str())
+
+    def _set_alarm_distance(self, event=None):
+        _var = self._alarm_distance_var.get()
+        try:
+            _var = int(_var)
+        except ValueError:
+            return
+        MH_LIST.parm_distance_alarm = _var
+
+    def _set_alarm_last_seen(self, event=None):
+        _var = self._alarm_seenSince_var.get()
+        try:
+            _var = int(_var)
+        except ValueError:
+            return
+        MH_LIST.parm_lastseen_alarm = _var
+
+    def _set_alarm_newCall(self, event=None):
+        MH_LIST.parm_new_call_alarm = bool(self._alarm_newCall_var.get())
 
     def entry_selected(self, event):
         for selected_item in self._tree.selection():

--- a/gui/guiMH.py
+++ b/gui/guiMH.py
@@ -44,7 +44,10 @@ class MHWin(tk.Toplevel):
         columns = (
             'mh_last_seen',
             'mh_first_seen' ,
-            'mh_port', 'mh_call',
+            'mh_port',
+            'mh_call',
+            'mh_loc',
+            'mh_dist',
             'mh_nPackets',
             'mh_REJ',
             'mh_route',
@@ -62,15 +65,22 @@ class MHWin(tk.Toplevel):
         self._tree.heading('mh_first_seen', text='Erste Paket', command=lambda: self._sort_entry('first'))
         self._tree.heading('mh_port', text='Port', command=lambda: self._sort_entry('port'))
         self._tree.heading('mh_call', text='Call', command=lambda: self._sort_entry('call'))
+        self._tree.heading('mh_loc', text='LOC', command=lambda: self._sort_entry('loc'))
+        self._tree.heading('mh_dist', text='km', command=lambda: self._sort_entry('dist'))
         self._tree.heading('mh_nPackets', text='Packets', command=lambda: self._sort_entry('pack'))
         self._tree.heading('mh_REJ', text='REJs', command=lambda: self._sort_entry('rej'))
         self._tree.heading('mh_route', text='Route', command=lambda: self._sort_entry('route'))
         self._tree.heading('mh_last_ip', text='AXIP', command=lambda: self._sort_entry('axip'))
         self._tree.heading('mh_ip_fail', text='Fail', command=lambda: self._sort_entry('axipfail'))
-        self._tree.column("mh_port", anchor=tk.CENTER, stretch=tk.NO, width=80)
-        self._tree.column("mh_nPackets", anchor=tk.CENTER, stretch=tk.NO, width=80)
-        self._tree.column("mh_REJ", anchor=tk.CENTER, stretch=tk.NO, width=55)
-        self._tree.column("mh_ip_fail", anchor=tk.CENTER, stretch=tk.NO, width=50)
+        self._tree.column("mh_last_seen", anchor=tk.W, stretch=tk.YES, width=180)
+        self._tree.column("mh_first_seen", anchor=tk.W, stretch=tk.YES, width=180)
+        self._tree.column("mh_call", anchor=tk.W, stretch=tk.YES, width=120)
+        self._tree.column("mh_loc", anchor=tk.W, stretch=tk.YES, width=100)
+        self._tree.column("mh_dist", anchor=tk.W, stretch=tk.YES, width=70)
+        self._tree.column("mh_port", anchor=tk.W, stretch=tk.NO, width=80)
+        self._tree.column("mh_nPackets", anchor=tk.W, stretch=tk.NO, width=80)
+        self._tree.column("mh_REJ", anchor=tk.W, stretch=tk.NO, width=55)
+        self._tree.column("mh_ip_fail", anchor=tk.W, stretch=tk.NO, width=50)
         # self.tree.column("# 2", anchor=tk.CENTER, stretch=tk.YES)
         # tree.column(1, stretch=True)
 
@@ -85,7 +95,7 @@ class MHWin(tk.Toplevel):
             record = item['values']
             # show a message
             call = record[3]
-            vias = record[6]
+            vias = record[8]
             port = record[2]
             port = int(port.split(' ')[0])
             if vias:
@@ -134,6 +144,8 @@ class MHWin(tk.Toplevel):
                 f'{conv_time_DE_str(ent.first_seen)}',
                 f'{ent.port_id} {ent.port}',
                 f'{ent.own_call}',
+                f'{ent.locator}',
+                f'{ent.distance}',
                 f'{ent.pac_n}',
                 f'{ent.rej_n}',
                 ' '.join(route),

--- a/gui/guiMain.py
+++ b/gui/guiMain.py
@@ -348,59 +348,59 @@ class SideTabbedFrame:
         self._update_side_mh()
         self._tree.bind('<<TreeviewSelect>>', self._entry_selected)
 
-        # Settings ##########################
+        # Global Settings ##########################
         # Global Sound
-        self.sound_on = tk.BooleanVar(self.tab4_settings)
         Checkbutton(self.tab4_settings,
                     text="Sound",
-                    variable=self.sound_on,
+                    variable=self._main_win.setting_sound,
                     ).place(x=10, y=10)
-        # self.sound_on.set(True)
         # Global Sprech
-        self.sprech_on = tk.BooleanVar(self.tab4_settings)
         sprech_btn = Checkbutton(self.tab4_settings,
                                  text="Sprachausgabe",
-                                 variable=self.sprech_on,
+                                 variable=self._main_win.setting_sprech,
                                  command=self._chk_sprech_on
                                  )
         sprech_btn.place(x=10, y=35)
-        if is_linux():
-            self.sprech_on.set(True)
-        else:
-            self.sprech_on.set(False)
+        if not is_linux():
             sprech_btn.configure(state='disabled')
-
         # Global Bake
-        self.bake_on = tk.BooleanVar(self.tab4_settings)
         Checkbutton(self.tab4_settings,
                     text="Baken",
-                    variable=self.bake_on,
+                    variable=self._main_win.setting_bake,
                     ).place(x=10, y=60)
-        self.bake_on.set(True)
-        # self.bake_on.set(True)
         # DX Alarm  > dx_alarm_on
-        self.tracer_on = tk.BooleanVar(self.tab4_settings)
-
-        _chk_btn = Checkbutton(self.tab4_settings,
-                               text="Tracer",
-                               variable=self.tracer_on,
-                               command=self._chk_tracer,
-                               # state='disabled'
-                               )
-        _chk_btn.place(x=10, y=85)
-
+        Checkbutton(self.tab4_settings,
+                    text="Tracer",
+                    variable=self._main_win.setting_tracer,
+                    command=self._chk_tracer,
+                    # state='disabled'
+                    ).place(x=10, y=85)
+        _auto_tracer_state = {
+            True: 'disabled',
+            False: 'normal'
+        }.get(self._main_win.get_tracer(), 'disabled')
+        self._autotracer_chk_btn = Checkbutton(self.tab4_settings,
+                                               text="Auto-Tracer",
+                                               variable=self._main_win.setting_auto_tracer,
+                                               command=self._chk_tracer,
+                                               state=_auto_tracer_state
+                                               )
+        self._autotracer_chk_btn.place(x=10, y=115)
+        Checkbutton(self.tab4_settings,
+                    text="DX-Alarm",
+                    variable=self._main_win.setting_dx_alarm,
+                    # command=self._chk_tracer,
+                    # state='disabled'
+                    ).place(x=10, y=145)
         # RX ECHO
-        self.rx_echo_on = tk.BooleanVar(self.tab4_settings)
-        _chk_btn = Checkbutton(self.tab4_settings,
-                               text="RX-Echo",
-                               variable=self.rx_echo_on,
-                               )
-        _chk_btn.place(x=10, y=115)
-
+        Checkbutton(self.tab4_settings,
+                    text="RX-Echo",
+                    variable=self._main_win.setting_rx_echo,
+                    ).place(x=10, y=175)
         ############
         # CH ECHO
-        self.chk_btn_default_clr = _chk_btn.cget('bg')
-        self.ch_echo_vars = {}
+        self._chk_btn_default_clr = self._autotracer_chk_btn.cget('bg')
+        self._ch_echo_vars = {}
         #################
         #################
         # Monitor Frame
@@ -560,7 +560,7 @@ class SideTabbedFrame:
         }
 
         self._chk_mon_port()
-        self._update_ch_echo()
+        # self._update_ch_echo()
         self._update_side_mh()
         self._update_side_trace()
 
@@ -570,19 +570,25 @@ class SideTabbedFrame:
         # self.tab2_mh.configure(bg=self.tab2_mh_def_bg_clr)
     """
 
-    def _update_ch_echo(self):
+    def set_auto_tracer_state(self):
+        _state = {
+            True: 'disabled',
+            False: 'normal'
+        }.get(self._main_win.get_tracer(), 'disabled')
+        self._autotracer_chk_btn.configure(state=_state)
 
+    def _update_ch_echo(self):
         # TODO AGAIN !!
         _tab = self.tab5_ch_links
         akt_ch_id = self._main_win.channel_index
         _var = tk.BooleanVar(_tab)
-        for ch_id in list(self.ch_echo_vars.keys()):
+        for ch_id in list(self._ch_echo_vars.keys()):
             if ch_id not in list(PORT_HANDLER.get_all_connections().keys()):
-                self.ch_echo_vars[ch_id][1].destroy()
-                del self.ch_echo_vars[ch_id]
+                self._ch_echo_vars[ch_id][1].destroy()
+                del self._ch_echo_vars[ch_id]
         for ch_id in list(PORT_HANDLER.get_all_connections().keys()):
             conn = PORT_HANDLER.get_all_connections()[ch_id]
-            if ch_id not in self.ch_echo_vars.keys():
+            if ch_id not in self._ch_echo_vars.keys():
                 chk_bt_var = tk.IntVar()
                 chk_bt = tk.Checkbutton(_tab,
                                         text=conn.to_call_str,
@@ -594,30 +600,30 @@ class SideTabbedFrame:
                 chk_bt.place(x=10, y=10 + (28 * (ch_id - 1)))
                 # _chk_bt.configure(state='disabled')
                 tmp = chk_bt_var, chk_bt
-                self.ch_echo_vars[ch_id] = tmp
+                self._ch_echo_vars[ch_id] = tmp
             else:
-                self.ch_echo_vars[ch_id][1].configure(state='normal')
-                self.ch_echo_vars[ch_id][1].configure(text=conn.to_call_str)
+                self._ch_echo_vars[ch_id][1].configure(state='normal')
+                self._ch_echo_vars[ch_id][1].configure(text=conn.to_call_str)
             if ch_id != akt_ch_id:
-                self.ch_echo_vars[ch_id][1].configure(state='normal')
+                self._ch_echo_vars[ch_id][1].configure(state='normal')
             else:
-                self.ch_echo_vars[ch_id][1].configure(state='disabled')
-            if akt_ch_id in self.ch_echo_vars.keys():
-                if self.ch_echo_vars[ch_id][0].get() and self.ch_echo_vars[akt_ch_id][0].get():
-                    self.ch_echo_vars[ch_id][1].configure(bg='green1')
-                    self.ch_echo_vars[akt_ch_id][1].configure(bg='green1')
+                self._ch_echo_vars[ch_id][1].configure(state='disabled')
+            if akt_ch_id in self._ch_echo_vars.keys():
+                if self._ch_echo_vars[ch_id][0].get() and self._ch_echo_vars[akt_ch_id][0].get():
+                    self._ch_echo_vars[ch_id][1].configure(bg='green1')
+                    self._ch_echo_vars[akt_ch_id][1].configure(bg='green1')
                 else:
-                    self.ch_echo_vars[ch_id][1].configure(bg=self.chk_btn_default_clr)
-                    self.ch_echo_vars[akt_ch_id][1].configure(bg=self.chk_btn_default_clr)
+                    self._ch_echo_vars[ch_id][1].configure(bg=self._chk_btn_default_clr)
+                    self._ch_echo_vars[akt_ch_id][1].configure(bg=self._chk_btn_default_clr)
 
         # self.sound_on.set(1)
 
     def _chk_ch_echo(self):
         # self.main_win.channel_index
-        for ch_id in list(self.ch_echo_vars.keys()):
-            _vars = self.ch_echo_vars[ch_id]
+        for ch_id in list(self._ch_echo_vars.keys()):
+            _vars = self._ch_echo_vars[ch_id]
             if ch_id != self._main_win.channel_index:
-                if _vars[0].get() and self.ch_echo_vars[self._main_win.channel_index][0].get():
+                if _vars[0].get() and self._ch_echo_vars[self._main_win.channel_index][0].get():
                     PORT_HANDLER.get_all_connections()[ch_id].ch_echo.append(
                         PORT_HANDLER.get_all_connections()[self._main_win.channel_index])
                     PORT_HANDLER.get_all_connections()[self._main_win.channel_index].ch_echo.append(
@@ -653,10 +659,7 @@ class SideTabbedFrame:
     """
 
     def _chk_tracer(self):
-        self._main_win.set_tracer(self.tracer_on.get())
-
-    def set_tracer_chk(self, state: bool):
-        self.tracer_on.set(state)
+        self._main_win.set_tracer()
 
     def _chk_rnr(self):
         conn = self._main_win.get_conn()
@@ -690,7 +693,8 @@ class SideTabbedFrame:
             _conn.calc_irtt()
 
     def _chk_sprech_on(self):
-        if self.sprech_on.get():
+
+        if self._main_win.setting_sprech.get():
             self.t2speech.configure(state='normal')
         else:
             self.t2speech.configure(state='disabled')
@@ -735,7 +739,7 @@ class SideTabbedFrame:
             # show a message
             call = record[1]
             vias = record[5]
-            port = record[2]
+            port = record[3]
             port = int(port.split(' ')[0])
             if vias:
                 call = f'{call} {vias}'
@@ -911,7 +915,7 @@ class SideTabbedFrame:
             self.rx_count_var.set('RX: --- kb')
 
         self.t2speech_var.set(self._main_win.get_ch_param().t2speech)
-        self._update_ch_echo()
+        # self._update_ch_echo()
 
     def set_max_frame(self):
         conn = self._main_win.get_conn()
@@ -1538,12 +1542,9 @@ class ChBtnFrm:
 class TkMainWin:
     def __init__(self):
         ######################################
-        # Init Vars
-        self._init_vars()
-        ######################################
         # GUI Stuff
         self.main_win = tk.Tk()
-        self.main_win.title("P.ython o.ther P.acket T.erminal {}".format(VER))
+        self.main_win.title(f"P.ython o.ther P.acket T.erminal {VER}")
         self.main_win.geometry("1400x850")
         try:
             self.main_win.iconbitmap("favicon.ico")
@@ -1554,12 +1555,16 @@ class TkMainWin:
         self.style = ttk.Style()
         # self.style.theme_use('classic')
         # self.style.theme_use('clam')
+        ######################################
+        # Init Vars
+        self._init_vars()
+        ######################################
+        # ....
         self.main_win.columnconfigure(0, minsize=500, weight=1)
         self.main_win.columnconfigure(1, minsize=2, weight=5)
         self.main_win.rowconfigure(0, minsize=3, weight=1)  # Boarder
         self.main_win.rowconfigure(1, minsize=220, weight=2)
         self.main_win.rowconfigure(2, minsize=28, weight=1)  # CH BTN
-        ############################
         ############################
         # Input Output TXT Frames and Status Bar
         self._txt_win = TxTframe(self)
@@ -1576,8 +1581,6 @@ class TkMainWin:
         # Channel Buttons
         self._ch_btn = ChBtnFrm(self)
         self._ch_btn.ch_btn_frame.grid(row=2, column=0, columnspan=1, sticky="nsew")
-        #########################
-
         #########################
         # Tabbed Frame right
         self._side_btn_frame_top = tk.Frame(self.main_win, width=200, height=540)
@@ -1600,11 +1603,6 @@ class TkMainWin:
         ##############
         # Side Frame
         self.tabbed_sideFrame = SideTabbedFrame(self)
-        self.setting_sound = self.tabbed_sideFrame.sound_on
-        self.setting_sprech = self.tabbed_sideFrame.sprech_on
-        self.setting_bake = self.tabbed_sideFrame.bake_on
-        self.setting_rx_echo = self.tabbed_sideFrame.rx_echo_on
-        # self.setting_dx_alarm = self.tabbed_sideFrame.dx_alarm_on
         ############################
         # Canvas Plot
         self._init_bw_plot()
@@ -1627,8 +1625,6 @@ class TkMainWin:
         self.main_win.mainloop()
 
     def __del__(self):
-        # self.disco_all()
-        # self.ax25_port_handler.close_all()
         pass
 
     def _destroy_win(self):
@@ -1667,11 +1663,29 @@ class TkMainWin:
         #####################
         # GUI VARS
         self.connect_history = {}
-
+        # GLb Settings
+        self.setting_sound = tk.BooleanVar(self.main_win)
+        self.setting_sprech = tk.BooleanVar(self.main_win)
+        self.setting_bake = tk.BooleanVar(self.main_win)
+        self.setting_rx_echo = tk.BooleanVar(self.main_win)
+        self.setting_tracer = tk.BooleanVar(self.main_win)
+        self.setting_auto_tracer = tk.BooleanVar(self.main_win)
+        self.setting_dx_alarm = tk.BooleanVar(self.main_win)
+        # Glb Settings Defaults
+        self.setting_sound.set(False)
+        self.setting_bake.set(True)
+        self.setting_rx_echo.set(False)
+        self.setting_tracer.set(False)
+        self.setting_auto_tracer.set(False)
+        self.setting_dx_alarm.set(True)
+        if is_linux():
+            self.setting_sprech.set(True)
+        else:
+            self.setting_sprech.set(False)
+        # Controlling
         self.ch_alarm = False
         self.ch_alarm_sound_one_time = False
         self.channel_index = 1
-
         self.mon_mode = 0
         self._mon_buff = []
         self._sound_th = None
@@ -1898,8 +1912,64 @@ class TkMainWin:
                   bg="HotPink2", width=12, command=self._kaffee).place(x=215, y=10)
         """
 
-    def _monitor_start_msg(self):
+    #######################################
+    # KEYBIND Stuff
+    def _set_binds(self):
+        self._inp_txt.bind("<ButtonRelease-1>", self._on_click_inp_txt)
 
+    def _set_keybinds(self):
+        self.main_win.unbind("<Key-F10>")
+        self.main_win.unbind("<KeyPress-F10>")
+        # self.main_win.bind("<KeyPress>",lambda event: self.callback(event))
+        self.main_win.bind('<F1>', lambda event: self.switch_channel(1))
+        self.main_win.bind('<F2>', lambda event: self.switch_channel(2))
+        self.main_win.bind('<F3>', lambda event: self.switch_channel(3))
+        self.main_win.bind('<F4>', lambda event: self.switch_channel(4))
+        self.main_win.bind('<F5>', lambda event: self.switch_channel(5))
+        self.main_win.bind('<F6>', lambda event: self.switch_channel(6))
+        self.main_win.bind('<F7>', lambda event: self.switch_channel(7))
+        self.main_win.bind('<F8>', lambda event: self.switch_channel(8))
+        self.main_win.bind('<F9>', lambda event: self.switch_channel(9))
+        self.main_win.bind('<F10>', lambda event: self.switch_channel(10))
+        self.main_win.bind('<F12>', lambda event: self.switch_channel(0))
+        self.main_win.bind('<Return>', self._snd_text)
+        self.main_win.bind('<KeyRelease-Return>', self._release_return)
+        self.main_win.bind('<Shift-KeyPress-Return>', self._shift_return)
+        self.main_win.bind('<KeyRelease-Left>', self._arrow_keys)
+        self.main_win.bind('<KeyRelease-Right>', self._arrow_keys)
+        self.main_win.bind('<KeyRelease-Up>', self._arrow_keys)
+        self.main_win.bind('<KeyRelease-Down>', self._arrow_keys)
+        # self.main_win.bind('<KP_Enter>', self.snd_text)
+        self.main_win.bind('<Alt-c>', lambda event: self.open_new_conn_win())
+        self.main_win.bind('<Escape>', lambda event: self.open_new_conn_win())
+        self.main_win.bind('<Alt-d>', lambda event: self._disco_conn())
+        self.main_win.bind('<Control-c>', lambda event: self._copy_select())
+        self.main_win.bind('<Control-x>', lambda event: self._cut_select())
+        # self.main_win.bind('<Control-v>', lambda event: self.clipboard_past())
+        self.main_win.bind('<Control-a>', lambda event: self._select_all())
+        self.main_win.bind('<Control-plus>', lambda event: self._increase_textsize())
+        self.main_win.bind('<Control-minus>', lambda event: self._decrease_textsize())
+        self.main_win.bind('<Control-Right>', lambda event: self._text_win_bigger())
+        self.main_win.bind('<Control-Left>', lambda event: self._text_win_smaller())
+
+        self.main_win.bind('<Key>', lambda event: self._any_key(event))
+
+    def _any_key(self, event: tk.Event):
+        if event.keycode == 104:  # Numpad Enter
+            self._snd_text(event)
+
+    def _arrow_keys(self, event=None):
+        self._on_click_inp_txt()
+
+    def _shift_return(self, event=None):
+        pass
+
+    def _release_return(self, event=None):
+        pass
+
+    ##########################
+    # Start Message in Monitor
+    def _monitor_start_msg(self):
         # tmp_lang = int(self.language)
         # self.language = random.choice([0, 1, 2, 3, 4, 5, 6, 7, 8])
         self.sprech(random.choice(WELCOME_SPEECH))
@@ -1926,6 +1996,36 @@ class TkMainWin:
                                         PORT_HANDLER.get_all_ports()[port_k].port_cfg.parm_PortParm[0],
                                         PORT_HANDLER.get_all_ports()[port_k].port_cfg.parm_PortParm[1]
                                         ))
+
+    ##########################
+    # GUI Sizing/Formatting Stuff
+    def _increase_textsize(self):
+        self.text_size += 1
+        self.text_size = max(self.text_size, 3)
+        width = self._inp_txt.cget('width')
+        self._inp_txt.configure(font=(FONT, self.text_size), width=width + 1)
+        self._out_txt.configure(font=(FONT, self.text_size), width=width + 1)
+        self._mon_txt.configure(font=(FONT, self.text_size), width=width + 1)
+
+    def _decrease_textsize(self):
+        self.text_size -= 1
+        self.text_size = max(self.text_size, 3)
+        width = self._inp_txt.cget('width')
+        self._inp_txt.configure(font=(FONT, self.text_size), width=width - 1)
+        self._out_txt.configure(font=(FONT, self.text_size), width=width - 1)
+        self._mon_txt.configure(font=(FONT, self.text_size), width=width - 1)
+
+    def _text_win_bigger(self):
+        _width = self._inp_txt.cget('width')
+        self._inp_txt.configure(width=_width + 1)
+        self._out_txt.configure(width=_width + 1)
+        self._mon_txt.configure(width=_width + 1)
+
+    def _text_win_smaller(self):
+        _width = self._inp_txt.cget('width')
+        self._inp_txt.configure(width=max(_width - 1, 56))
+        self._out_txt.configure(width=max(_width - 1, 56))
+        self._mon_txt.configure(width=max(_width - 1, 56))
 
     ##########################
     # Clipboard Stuff
@@ -2006,87 +2106,6 @@ class TkMainWin:
     def _save_monitor_to_file(self):
         data = self._mon_txt.get('1.0', tk.END)
         save_file_dialog(data)
-
-    def _set_binds(self):
-        self._inp_txt.bind("<ButtonRelease-1>", self._on_click_inp_txt)
-
-    def _set_keybinds(self):
-        self.main_win.unbind("<Key-F10>")
-        self.main_win.unbind("<KeyPress-F10>")
-        # self.main_win.bind("<KeyPress>",lambda event: self.callback(event))
-        self.main_win.bind('<F1>', lambda event: self.switch_channel(1))
-        self.main_win.bind('<F2>', lambda event: self.switch_channel(2))
-        self.main_win.bind('<F3>', lambda event: self.switch_channel(3))
-        self.main_win.bind('<F4>', lambda event: self.switch_channel(4))
-        self.main_win.bind('<F5>', lambda event: self.switch_channel(5))
-        self.main_win.bind('<F6>', lambda event: self.switch_channel(6))
-        self.main_win.bind('<F7>', lambda event: self.switch_channel(7))
-        self.main_win.bind('<F8>', lambda event: self.switch_channel(8))
-        self.main_win.bind('<F9>', lambda event: self.switch_channel(9))
-        self.main_win.bind('<F10>', lambda event: self.switch_channel(10))
-        self.main_win.bind('<F12>', lambda event: self.switch_channel(0))
-        self.main_win.bind('<Return>', self._snd_text)
-        self.main_win.bind('<KeyRelease-Return>', self._release_return)
-        self.main_win.bind('<Shift-KeyPress-Return>', self._shift_return)
-        self.main_win.bind('<KeyRelease-Left>', self._arrow_keys)
-        self.main_win.bind('<KeyRelease-Right>', self._arrow_keys)
-        self.main_win.bind('<KeyRelease-Up>', self._arrow_keys)
-        self.main_win.bind('<KeyRelease-Down>', self._arrow_keys)
-        # self.main_win.bind('<KP_Enter>', self.snd_text)
-        self.main_win.bind('<Alt-c>', lambda event: self.open_new_conn_win())
-        self.main_win.bind('<Escape>', lambda event: self.open_new_conn_win())
-        self.main_win.bind('<Alt-d>', lambda event: self._disco_conn())
-        self.main_win.bind('<Control-c>', lambda event: self._copy_select())
-        self.main_win.bind('<Control-x>', lambda event: self._cut_select())
-        # self.main_win.bind('<Control-v>', lambda event: self.clipboard_past())
-        self.main_win.bind('<Control-a>', lambda event: self._select_all())
-        self.main_win.bind('<Control-plus>', lambda event: self._increase_textsize())
-        self.main_win.bind('<Control-minus>', lambda event: self._decrease_textsize())
-        self.main_win.bind('<Control-Right>', lambda event: self._text_win_bigger())
-        self.main_win.bind('<Control-Left>', lambda event: self._text_win_smaller())
-
-        self.main_win.bind('<Key>', lambda event: self._any_key(event))
-
-    def _any_key(self, event: tk.Event):
-        if event.keycode == 104:  # Numpad Enter
-            self._snd_text(event)
-
-    def _arrow_keys(self, event=None):
-        self._on_click_inp_txt()
-
-    def _shift_return(self, event=None):
-        pass
-
-    def _release_return(self, event=None):
-        pass
-
-    def _increase_textsize(self):
-        self.text_size += 1
-        self.text_size = max(self.text_size, 3)
-        width = self._inp_txt.cget('width')
-        self._inp_txt.configure(font=(FONT, self.text_size), width=width + 1)
-        self._out_txt.configure(font=(FONT, self.text_size), width=width + 1)
-        self._mon_txt.configure(font=(FONT, self.text_size), width=width + 1)
-
-    def _decrease_textsize(self):
-        self.text_size -= 1
-        self.text_size = max(self.text_size, 3)
-        width = self._inp_txt.cget('width')
-        self._inp_txt.configure(font=(FONT, self.text_size), width=width - 1)
-        self._out_txt.configure(font=(FONT, self.text_size), width=width - 1)
-        self._mon_txt.configure(font=(FONT, self.text_size), width=width - 1)
-
-    def _text_win_bigger(self):
-        _width = self._inp_txt.cget('width')
-        self._inp_txt.configure(width=_width + 1)
-        self._out_txt.configure(width=_width + 1)
-        self._mon_txt.configure(width=_width + 1)
-
-    def _text_win_smaller(self):
-        _width = self._inp_txt.cget('width')
-        self._inp_txt.configure(width=max(_width - 1, 56))
-        self._out_txt.configure(width=max(_width - 1, 56))
-        self._mon_txt.configure(width=max(_width - 1, 56))
 
     def change_conn_btn(self):
         # TODO Nur triggern wenn ch_btn click | neue in conn | disco
@@ -3058,26 +3077,36 @@ class TkMainWin:
     def get_ch_new_data_tr(self, ch_id):
         return bool(self._win_buf[ch_id].new_data_tr)
 
-    @staticmethod
-    def set_tracer(state: bool):
+    def set_tracer(self, state=None):
         _ais_obj = PORT_HANDLER.get_aprs_ais()
         if _ais_obj is not None:
-            _ais_obj.be_tracer_active = bool(state)
+            _ais_obj.be_tracer_active = bool(self.setting_tracer.get())
+        else:
+            self.setting_tracer.set(False)
+        self.tabbed_sideFrame.set_auto_tracer_state()
 
+    @staticmethod
+    def get_tracer():
+        _ais_obj = PORT_HANDLER.get_aprs_ais()
+        if _ais_obj is not None:
+            return _ais_obj.be_tracer_active
+        return False
 
-"""
-if __name__ == '__main__':
-    logger.info(f"PoPT_{VER} start....")
-    #############
-    # INIT GUI
-    # TODO: if setting_gui (running without GUI option):
-    logger.info(f"Loading GUI.")
-    root = tk.Tk()
-    # gui.guiMain.TkMainWin()
-    TkMainWin(root)
-    root.mainloop()
+    def set_tracer_fm_aprs(self):
+        _ais_obj = PORT_HANDLER.get_aprs_ais()
+        if _ais_obj is not None:
+            self.setting_tracer.set(_ais_obj.be_tracer_active)
+        else:
+            self.setting_tracer.set(False)
+        self.tabbed_sideFrame.set_auto_tracer_state()
 
-    logger.info(f"PoPT_{VER} ENDE.")
-    print('ENDE')
-
-"""
+    def set_auto_tracer(self, event=None):
+        _ais_obj = PORT_HANDLER.get_aprs_ais()
+        set_to = False
+        if _ais_obj is not None:
+            if self.setting_tracer.get():
+                set_to = False
+            else:
+                set_to = not bool(self.setting_auto_tracer.get())
+        self.setting_auto_tracer.set(set_to)
+        self.tabbed_sideFrame.set_auto_tracer_state()

--- a/gui/guiMain.py
+++ b/gui/guiMain.py
@@ -1733,13 +1733,19 @@ class TkMainWin:
         else:
             self.setting_sprech.set(False)
         # MH
-        MH_LIST.parm_new_call_alarm = True
+        """
         MH_LIST.parm_distance_alarm = 50
         MH_LIST.parm_lastseen_alarm = 1
+        """
+        MH_LIST.parm_new_call_alarm = True
+        # Set Port 0 for DX Alarm as default # TODO remove
+        if PORT_HANDLER.get_port_by_index(0):
+            MH_LIST.parm_alarm_ports = [0]
+        else:
+            MH_LIST.parm_alarm_ports = []
 
     def _init_bw_plot(self):
         self._bw_fig = Figure(figsize=(8, 5), dpi=80)
-        # plt.style.use('dark_background')
         self._ax = self._bw_fig.add_subplot(111)
         self._bw_fig.subplots_adjust(left=0.1, right=0.95, top=0.99, bottom=0.1)
         self._ax.axis([0, 10, 0, 100])  # TODO As Option

--- a/gui/guiMain.py
+++ b/gui/guiMain.py
@@ -89,39 +89,39 @@ class SideTabbedFrame:
         self.style = main_cl.style
         self.ch_index = main_cl.channel_index
 
-        self._tab_side_frame = tk.Frame(
+        _tab_side_frame = tk.Frame(
             main_cl.get_side_frame(),
             # width=300,
             height=400
         )
-        self._tab_side_frame.grid(row=3, column=0, columnspan=6, pady=10, sticky="nsew")
+        _tab_side_frame.grid(row=3, column=0, columnspan=6, pady=10, sticky="nsew")
         self._tabControl = ttk.Notebook(
-            self._tab_side_frame,
+            _tab_side_frame,
             height=300,
             # width=500
         )
 
         tab1_kanal = ttk.Frame(self._tabControl)
         # self.tab1_1_RTT = ttk.Frame(self._tabControl)
-        self.tab2_mh = tk.Frame(self._tabControl)
-        # self.tab2_mh.bind("<Button-1>", self.reset_dx_alarm)
-        self.tab2_mh_def_bg_clr = self.tab2_mh.cget('bg')
-        self.tab4_settings = ttk.Frame(self._tabControl)
-        self.tab5_ch_links = ttk.Frame(self._tabControl)  # TODO
-        self.tab6_monitor = ttk.Frame(self._tabControl)
-        self.tab7_tracer = ttk.Frame(self._tabControl)
+        tab2_mh = tk.Frame(self._tabControl)
+        # tab2_mh.bind("<Button-1>", self.reset_dx_alarm)
+        # self.tab2_mh_def_bg_clr = tab2_mh.cget('bg')
+        tab4_settings = ttk.Frame(self._tabControl)
+        # self.tab5_ch_links = ttk.Frame(self._tabControl)  # TODO
+        tab6_monitor = ttk.Frame(self._tabControl)
+        tab7_tracer = ttk.Frame(self._tabControl)
 
         self._tabControl.add(tab1_kanal, text='Kanal')
         # tab3 = ttk.Frame(self._tabControl)                         # TODO
         # self._tabControl.add(tab3, text='Ports')                   # TODO
-        self._tabControl.add(self.tab4_settings, text='Global')
-        self._tabControl.add(self.tab6_monitor, text='Monitor')
-        self._tabControl.add(self.tab2_mh, text='MH')
-        self._tabControl.add(self.tab7_tracer, text='Tracer')
+        self._tabControl.add(tab4_settings, text='Global')
+        self._tabControl.add(tab6_monitor, text='Monitor')
+        self._tabControl.add(tab2_mh, text='MH')
+        self._tabControl.add(tab7_tracer, text='Tracer')
 
         # self._tabControl.add(self.tab5_ch_links, text='CH-Echo')   # TODO
         self._tabControl.pack(expand=0, fill="both")
-        self._tabControl.select(self.tab2_mh)
+        self._tabControl.select(tab2_mh)
         ################################################
         # Kanal
         parm_y = 20
@@ -317,7 +317,7 @@ class SideTabbedFrame:
         ################################
         # MH ##########################
         # TREE
-        self.tab2_mh.columnconfigure(0, minsize=300, weight=1)
+        tab2_mh.columnconfigure(0, minsize=300, weight=1)
 
         columns = (
             'mh_last_seen',
@@ -328,7 +328,7 @@ class SideTabbedFrame:
             'mh_route',
         )
 
-        self._tree = ttk.Treeview(self.tab2_mh, columns=columns, show='headings')
+        self._tree = ttk.Treeview(tab2_mh, columns=columns, show='headings')
         self._tree.grid(row=0, column=0, sticky='nsew')
 
         self._tree.heading('mh_last_seen', text='Zeit')
@@ -351,12 +351,12 @@ class SideTabbedFrame:
 
         # Global Settings ##########################
         # Global Sound
-        Checkbutton(self.tab4_settings,
+        Checkbutton(tab4_settings,
                     text="Sound",
                     variable=self._main_win.setting_sound,
                     ).place(x=10, y=10)
         # Global Sprech
-        sprech_btn = Checkbutton(self.tab4_settings,
+        sprech_btn = Checkbutton(tab4_settings,
                                  text="Sprachausgabe",
                                  variable=self._main_win.setting_sprech,
                                  command=self._chk_sprech_on
@@ -365,12 +365,12 @@ class SideTabbedFrame:
         if not is_linux():
             sprech_btn.configure(state='disabled')
         # Global Bake
-        Checkbutton(self.tab4_settings,
+        Checkbutton(tab4_settings,
                     text="Baken",
                     variable=self._main_win.setting_bake,
                     ).place(x=10, y=60)
         # DX Alarm  > dx_alarm_on
-        Checkbutton(self.tab4_settings,
+        Checkbutton(tab4_settings,
                     text="Tracer",
                     variable=self._main_win.setting_tracer,
                     command=self._chk_tracer,
@@ -380,21 +380,21 @@ class SideTabbedFrame:
             True: 'disabled',
             False: 'normal'
         }.get(self._main_win.get_tracer(), 'disabled')
-        self._autotracer_chk_btn = Checkbutton(self.tab4_settings,
+        self._autotracer_chk_btn = Checkbutton(tab4_settings,
                                                text="Auto-Tracer",
                                                variable=self._main_win.setting_auto_tracer,
                                                command=self._chk_auto_tracer,
                                                state=_auto_tracer_state
                                                )
         self._autotracer_chk_btn.place(x=10, y=110)
-        Checkbutton(self.tab4_settings,
+        Checkbutton(tab4_settings,
                     text="DX-Alarm",
                     variable=self._main_win.setting_dx_alarm,
                     command=self._main_win.set_dx_alarm,
                     # state='disabled'
                     ).place(x=10, y=135)
         # RX ECHO
-        Checkbutton(self.tab4_settings,
+        Checkbutton(tab4_settings,
                     text="RX-Echo",
                     variable=self._main_win.setting_rx_echo,
                     ).place(x=10, y=160)
@@ -408,16 +408,16 @@ class SideTabbedFrame:
         # Address
         _x = 10
         _y = 10
-        self.to_add_var = tk.StringVar(self.tab6_monitor)
-        tk.Label(self.tab6_monitor, text=f"{STR_TABLE['to'][self._lang]}:").place(x=_x, y=_y)
-        self.to_add_ent = tk.Entry(self.tab6_monitor, textvariable=self.to_add_var)
+        self.to_add_var = tk.StringVar(tab6_monitor)
+        tk.Label(tab6_monitor, text=f"{STR_TABLE['to'][self._lang]}:").place(x=_x, y=_y)
+        self.to_add_ent = tk.Entry(tab6_monitor, textvariable=self.to_add_var)
         self.to_add_ent.place(x=_x + 40, y=_y)
 
         # CMD/RPT
         _x = 10
         _y = 80
-        self.cmd_var = tk.BooleanVar(self.tab6_monitor)
-        self.cmd_ent = tk.Checkbutton(self.tab6_monitor,
+        self.cmd_var = tk.BooleanVar(tab6_monitor)
+        self.cmd_ent = tk.Checkbutton(tab6_monitor,
                                       variable=self.cmd_var,
                                       text='CMD/RPT')
         self.cmd_ent.place(x=_x, y=_y)
@@ -425,8 +425,8 @@ class SideTabbedFrame:
         # Poll
         _x = 10
         _y = 105
-        self.poll_var = tk.BooleanVar(self.tab6_monitor)
-        self.poll_ent = tk.Checkbutton(self.tab6_monitor,
+        self.poll_var = tk.BooleanVar(tab6_monitor)
+        self.poll_ent = tk.Checkbutton(tab6_monitor,
                                        variable=self.poll_var,
                                        text='Poll')
         self.poll_ent.place(x=_x, y=_y)
@@ -434,13 +434,13 @@ class SideTabbedFrame:
         # Port
         _x = 40
         _y = 140
-        tk.Label(self.tab6_monitor, text=f"{STR_TABLE['port'][self._lang]}:").place(x=_x, y=_y)
-        self.mon_port_var = tk.StringVar(self.tab6_monitor)
+        tk.Label(tab6_monitor, text=f"{STR_TABLE['port'][self._lang]}:").place(x=_x, y=_y)
+        self.mon_port_var = tk.StringVar(tab6_monitor)
         self.mon_port_var.set('0')
         _vals = ['0']
         if PORT_HANDLER.get_all_ports().keys():
             _vals = [str(x) for x in list(PORT_HANDLER.get_all_ports().keys())]
-        self.mon_port_ent = tk.ttk.Combobox(self.tab6_monitor,
+        self.mon_port_ent = tk.ttk.Combobox(tab6_monitor,
                                             width=4,
                                             textvariable=self.mon_port_var,
                                             values=_vals,
@@ -450,11 +450,11 @@ class SideTabbedFrame:
         # Calls
         _x = 40
         _y = 175
-        self.mon_call_var = tk.StringVar(self.tab6_monitor)
+        self.mon_call_var = tk.StringVar(tab6_monitor)
         _vals = []
         # if self.main_win.ax25_port_handler.ax25_ports.keys():
         #     _vals = [str(x) for x in list(self.main_win.ax25_port_handler.ax25_ports.keys())]
-        self.mon_call_ent = tk.ttk.Combobox(self.tab6_monitor,
+        self.mon_call_ent = tk.ttk.Combobox(tab6_monitor,
                                             width=9,
                                             textvariable=self.mon_call_var,
                                             values=_vals,
@@ -464,8 +464,8 @@ class SideTabbedFrame:
         # Auto Scrolling
         _x = 10
         _y = 210
-        self.mon_scroll_var = tk.BooleanVar(self.tab6_monitor)
-        self.mon_scroll_ent = tk.Checkbutton(self.tab6_monitor,
+        self.mon_scroll_var = tk.BooleanVar(tab6_monitor)
+        self.mon_scroll_ent = tk.Checkbutton(tab6_monitor,
                                              variable=self.mon_scroll_var,
                                              text=STR_TABLE['scrolling'][self._lang])
         self.mon_scroll_ent.place(x=_x, y=_y)
@@ -473,9 +473,9 @@ class SideTabbedFrame:
         # Monitor APRS Decoding Output
         _x = 10
         _y = 235
-        self.mon_aprs_var = tk.BooleanVar(self.tab6_monitor)
+        self.mon_aprs_var = tk.BooleanVar(tab6_monitor)
         self.mon_aprs_var.set(True)
-        self.mon_aprs_ent = tk.Checkbutton(self.tab6_monitor,
+        self.mon_aprs_ent = tk.Checkbutton(tab6_monitor,
                                            variable=self.mon_aprs_var,
                                            text='APRS-Decoding')
         self.mon_aprs_ent.place(x=_x, y=_y)
@@ -483,15 +483,15 @@ class SideTabbedFrame:
         # PID
         _x = 10
         _y = 45
-        self.mon_pid_var = tk.StringVar(self.tab6_monitor)
-        tk.Label(self.tab6_monitor, text='PID:').place(x=_x, y=_y)
+        self.mon_pid_var = tk.StringVar(tab6_monitor)
+        tk.Label(tab6_monitor, text='PID:').place(x=_x, y=_y)
         pid = PIDByte()
         pac_types = dict(pid.pac_types)
         _vals = []
         for x in list(pac_types.keys()):
             pid.pac_types[int(x)]()
             _vals.append(f"{str(hex(int(x))).upper()}>{pid.flag}")
-        self.mon_pid_ent = tk.ttk.Combobox(self.tab6_monitor,
+        self.mon_pid_ent = tk.ttk.Combobox(tab6_monitor,
                                            width=20,
                                            values=_vals,
                                            textvariable=self.mon_pid_var)
@@ -502,10 +502,10 @@ class SideTabbedFrame:
         self.mon_port_on_vars = {}
         all_ports = PORT_HANDLER.get_all_ports()
         for port_id in all_ports:
-            self.mon_port_on_vars[port_id] = tk.BooleanVar(self.tab6_monitor)
+            self.mon_port_on_vars[port_id] = tk.BooleanVar(tab6_monitor)
             _x = 170
             _y = 80 + (25 * port_id)
-            tk.Checkbutton(self.tab6_monitor,
+            tk.Checkbutton(tab6_monitor,
                            text=f"Port {port_id}",
                            variable=self.mon_port_on_vars[port_id],
                            command=self._chk_mon_port_filter
@@ -514,10 +514,10 @@ class SideTabbedFrame:
         ################################
         # TRACER
         # TREE
-        self.tab7_tracer.columnconfigure(0, minsize=150, weight=1)
-        self.tab7_tracer.columnconfigure(1, minsize=150, weight=1)
-        self.tab7_tracer.rowconfigure(0, minsize=100, weight=1)
-        self.tab7_tracer.rowconfigure(1, minsize=50, weight=1)
+        tab7_tracer.columnconfigure(0, minsize=150, weight=1)
+        tab7_tracer.columnconfigure(1, minsize=150, weight=1)
+        tab7_tracer.rowconfigure(0, minsize=100, weight=1)
+        tab7_tracer.rowconfigure(1, minsize=50, weight=1)
 
         tracer_columns = (
             'rx_time',
@@ -527,7 +527,7 @@ class SideTabbedFrame:
             'path',
         )
 
-        self._trace_tree = ttk.Treeview(self.tab7_tracer, columns=tracer_columns, show='headings')
+        self._trace_tree = ttk.Treeview(tab7_tracer, columns=tracer_columns, show='headings')
         self._trace_tree.grid(row=0, column=0, columnspan=2, sticky='nsew')
 
         self._trace_tree.heading('rx_time', text='Zeit')
@@ -545,11 +545,11 @@ class SideTabbedFrame:
         self._trace_tree_data_old = {}
         self._update_side_trace()
 
-        tk.Button(self.tab7_tracer,
+        tk.Button(tab7_tracer,
                   text="SEND",
                   command=self._tracer_send
                   ).grid(row=1, column=0, padx=10)
-        # tk.Button(self.tab7_tracer, text="SEND").grid(row=1, column=1, padx=10)
+        # tk.Button(tab7_tracer, text="SEND").grid(row=1, column=1, padx=10)
         self._trace_tree.bind('<<TreeviewSelect>>', self._trace_entry_selected)
 
         ##################
@@ -568,7 +568,7 @@ class SideTabbedFrame:
     """
     def reset_dx_alarm(self, event=None):
         self._main_win.reset_dx_alarm()
-        # self.tab2_mh.configure(bg=self.tab2_mh_def_bg_clr)
+        # tab2_mh.configure(bg=self.tab2_mh_def_bg_clr)
     """
 
     def set_auto_tracer_state(self):
@@ -946,32 +946,32 @@ class SideTabbedFrame:
 class TxTframe:
     def __init__(self, main_win):
 
-        self.pw = ttk.PanedWindow(orient=tk.VERTICAL)
+        self._pw = ttk.PanedWindow(orient=tk.VERTICAL)
         self._main_class = main_win
-        self.text_size = main_win.text_size
+        self._text_size = main_win.text_size
         ###################
         # Input Win
-        self.status_frame = tk.Frame(self.pw, width=500, height=320, bd=0, borderwidth=0, bg=STAT_BAR_CLR)
-        self.status_frame.pack(side=tk.BOTTOM, expand=0)
+        self._status_frame = tk.Frame(self._pw, width=500, height=320, bd=0, borderwidth=0, bg=STAT_BAR_CLR)
+        self._status_frame.pack(side=tk.BOTTOM, expand=0)
 
-        self.status_frame.columnconfigure(1, minsize=60, weight=2)  # Name
-        self.status_frame.columnconfigure(2, minsize=40, weight=3)  # Status
-        self.status_frame.columnconfigure(3, minsize=40, weight=4)  # unACK
-        self.status_frame.columnconfigure(4, minsize=40, weight=4)  # VS VR
-        self.status_frame.columnconfigure(5, minsize=20, weight=5)  # N2
-        self.status_frame.columnconfigure(6, minsize=20, weight=5)  # T1
-        self.status_frame.columnconfigure(7, minsize=20, weight=5)  # T1
-        self.status_frame.columnconfigure(8, minsize=20, weight=5)  # T2
-        self.status_frame.columnconfigure(9, minsize=20, weight=5)  # T3
-        self.status_frame.columnconfigure(10, minsize=50, weight=1)  # RX Beep
-        self.status_frame.columnconfigure(11, minsize=20, weight=1)  # TimeStamp
-        self.status_frame.rowconfigure(0, weight=1)  # Stat
-        self.status_frame.rowconfigure(1, minsize=20, weight=0)  # Out
+        self._status_frame.columnconfigure(1, minsize=60, weight=2)  # Name
+        self._status_frame.columnconfigure(2, minsize=40, weight=3)  # Status
+        self._status_frame.columnconfigure(3, minsize=40, weight=4)  # unACK
+        self._status_frame.columnconfigure(4, minsize=40, weight=4)  # VS VR
+        self._status_frame.columnconfigure(5, minsize=20, weight=5)  # N2
+        self._status_frame.columnconfigure(6, minsize=20, weight=5)  # T1
+        self._status_frame.columnconfigure(7, minsize=20, weight=5)  # T1
+        self._status_frame.columnconfigure(8, minsize=20, weight=5)  # T2
+        self._status_frame.columnconfigure(9, minsize=20, weight=5)  # T3
+        self._status_frame.columnconfigure(10, minsize=50, weight=1)  # RX Beep
+        self._status_frame.columnconfigure(11, minsize=20, weight=1)  # TimeStamp
+        self._status_frame.rowconfigure(0, weight=1)  # Stat
+        self._status_frame.rowconfigure(1, minsize=20, weight=0)  # Out
 
-        self.in_txt_win = scrolledtext.ScrolledText(self.status_frame,
+        self.in_txt_win = scrolledtext.ScrolledText(self._status_frame,
                                                     background=TXT_BACKGROUND_CLR,
                                                     foreground=TXT_INP_CLR,
-                                                    font=(FONT, self.text_size),
+                                                    font=(FONT, self._text_size),
                                                     insertbackground=TXT_INP_CURSOR_CLR,
                                                     height=100,
                                                     width=82,
@@ -983,61 +983,61 @@ class TxTframe:
         self.in_txt_win.grid(row=0, column=0, columnspan=12, sticky="nsew")
         ##############
         # Status Frame
-        self.status_name = Label(self.status_frame, text="", font=(FONT_STAT_BAR, TEXT_SIZE_STATUS),
+        self.status_name = Label(self._status_frame, text="", font=(FONT_STAT_BAR, TEXT_SIZE_STATUS),
                                  foreground=STAT_BAR_TXT_CLR,
                                  bg=STAT_BAR_CLR)
         self.status_name.grid(row=1, column=1, sticky="nsew")
 
-        self.status_status = Label(self.status_frame, text="",
+        self.status_status = Label(self._status_frame, text="",
                                    font=(FONT_STAT_BAR, TEXT_SIZE_STATUS),
                                    bg=STAT_BAR_CLR,
                                    foreground=STAT_BAR_TXT_CLR)
         self.status_status.grid(row=1, column=2, sticky="nsew")
 
-        self.status_unack = Label(self.status_frame, text="",
+        self.status_unack = Label(self._status_frame, text="",
                                   foreground=STAT_BAR_TXT_CLR,
                                   font=(FONT_STAT_BAR, TEXT_SIZE_STATUS),
                                   bg=STAT_BAR_CLR)
         self.status_unack.grid(row=1, column=3, sticky="nsew")
 
-        self.status_vs = Label(self.status_frame, text="",
+        self.status_vs = Label(self._status_frame, text="",
                                font=(FONT_STAT_BAR, TEXT_SIZE_STATUS),
                                bg=STAT_BAR_CLR,
                                foreground=STAT_BAR_TXT_CLR)
         self.status_vs.grid(row=1, column=4, sticky="nsew")
 
-        self.status_n2 = Label(self.status_frame, text="",
+        self.status_n2 = Label(self._status_frame, text="",
                                font=(FONT_STAT_BAR, TEXT_SIZE_STATUS),
                                bg=STAT_BAR_CLR,
                                foreground=STAT_BAR_TXT_CLR)
         self.status_n2.grid(row=1, column=7, sticky="nsew")
 
-        self.status_t1 = Label(self.status_frame, text="",
+        self.status_t1 = Label(self._status_frame, text="",
                                font=(FONT_STAT_BAR, TEXT_SIZE_STATUS),
                                bg=STAT_BAR_CLR,
                                foreground=STAT_BAR_TXT_CLR)
         self.status_t1.grid(row=1, column=8, sticky="nsew")
         # PARM T2
-        self.status_t2 = Label(self.status_frame, text="",
+        self.status_t2 = Label(self._status_frame, text="",
                                font=(FONT_STAT_BAR, TEXT_SIZE_STATUS),
                                bg=STAT_BAR_CLR,
                                foreground=STAT_BAR_TXT_CLR)
         self.status_t2.grid(row=1, column=5, sticky="nsew")
         # RTT
-        self.status_rtt = Label(self.status_frame, text="",
+        self.status_rtt = Label(self._status_frame, text="",
                                 font=(FONT_STAT_BAR, TEXT_SIZE_STATUS),
                                 bg=STAT_BAR_CLR,
                                 foreground=STAT_BAR_TXT_CLR)
         self.status_rtt.grid(row=1, column=6, sticky="nsew")
 
-        self.status_t3 = Label(self.status_frame, text="",
+        self.status_t3 = Label(self._status_frame, text="",
                                font=(FONT_STAT_BAR, TEXT_SIZE_STATUS),
                                bg=STAT_BAR_CLR,
                                foreground=STAT_BAR_TXT_CLR)
         self.status_t3.grid(row=1, column=9, sticky="nsew")
         # Checkbox RX-BEEP
         self.rx_beep_var = tk.IntVar()
-        self.rx_beep_box = Checkbutton(self.status_frame,
+        self.rx_beep_box = Checkbutton(self._status_frame,
                                        text="RX-BEEP",
                                        bg=STAT_BAR_CLR,
                                        font=(FONT_STAT_BAR, TEXT_SIZE_STATUS),
@@ -1051,7 +1051,7 @@ class TxTframe:
         self.rx_beep_box.grid(row=1, column=10, sticky="nsew")
         # TODO Checkbox Time Stamp
         self.ts_box_var = tk.IntVar()
-        self.ts_box_box = Checkbutton(self.status_frame,
+        self.ts_box_box = Checkbutton(self._status_frame,
                                       text="T-S",
                                       font=(FONT_STAT_BAR, TEXT_SIZE_STATUS),
                                       bg=STAT_BAR_CLR,
@@ -1064,28 +1064,28 @@ class TxTframe:
                                       state='disabled'
                                       )
         self.ts_box_box.grid(row=1, column=11, sticky="nsew")
-        self.status_frame.pack(side=tk.BOTTOM)
+        self._status_frame.pack(side=tk.BOTTOM)
 
         ####################
         # Output
-        self.out_frame = tk.Frame(self.pw, width=500, height=320, bd=0, borderwidth=0, )
-        self.out_frame.pack(side=tk.BOTTOM, expand=0)
-        self.out_frame.rowconfigure(1, minsize=22, weight=1)
-        self.out_frame.rowconfigure(0, weight=1)
-        self.out_frame.columnconfigure(0, minsize=3, weight=0)  # Spacer
-        self.out_frame.columnconfigure(1, minsize=80, weight=2)  # Name
-        self.out_frame.columnconfigure(2, minsize=60, weight=3)  # QTH
-        self.out_frame.columnconfigure(3, minsize=20, weight=4)  # LOC
-        self.out_frame.columnconfigure(4, minsize=20, weight=5)  # Typ
-        self.out_frame.columnconfigure(5, minsize=80, weight=4)  # Software
-        self.out_frame.columnconfigure(6, minsize=28, weight=4)  # Status (PIPE/FT)
-        self.out_frame.columnconfigure(7, minsize=30, weight=4)  # Conn Timer
-        self.out_frame.columnconfigure(8, minsize=30, weight=4)  # Text Encoding
-        self.out_frame.columnconfigure(9, minsize=3, weight=0)  # Spacer
-        self.out_txt_win = scrolledtext.ScrolledText(self.out_frame,
+        self._out_frame = tk.Frame(self._pw, width=500, height=320, bd=0, borderwidth=0, )
+        self._out_frame.pack(side=tk.BOTTOM, expand=0)
+        self._out_frame.rowconfigure(1, minsize=22, weight=1)
+        self._out_frame.rowconfigure(0, weight=1)
+        self._out_frame.columnconfigure(0, minsize=3, weight=0)  # Spacer
+        self._out_frame.columnconfigure(1, minsize=80, weight=2)  # Name
+        self._out_frame.columnconfigure(2, minsize=60, weight=3)  # QTH
+        self._out_frame.columnconfigure(3, minsize=20, weight=4)  # LOC
+        self._out_frame.columnconfigure(4, minsize=20, weight=5)  # Typ
+        self._out_frame.columnconfigure(5, minsize=80, weight=4)  # Software
+        self._out_frame.columnconfigure(6, minsize=28, weight=4)  # Status (PIPE/FT)
+        self._out_frame.columnconfigure(7, minsize=30, weight=4)  # Conn Timer
+        self._out_frame.columnconfigure(8, minsize=30, weight=4)  # Text Encoding
+        self._out_frame.columnconfigure(9, minsize=3, weight=0)  # Spacer
+        self.out_txt_win = scrolledtext.ScrolledText(self._out_frame,
                                                      background=TXT_BACKGROUND_CLR,
                                                      foreground=TXT_OUT_CLR,
-                                                     font=(FONT, self.text_size),
+                                                     font=(FONT, self._text_size),
                                                      height=100,
                                                      width=82,
                                                      bd=0,
@@ -1095,16 +1095,16 @@ class TxTframe:
         self.out_txt_win.tag_config("input", foreground="yellow")
         self.out_txt_win.grid(row=0, column=0, columnspan=10, sticky="nsew")
         # Stat INFO (Name,QTH usw)
-        self.stat_info_name_var = tk.StringVar(self.out_frame)
-        self.stat_info_qth_var = tk.StringVar(self.out_frame)
-        self.stat_info_loc_var = tk.StringVar(self.out_frame)
-        self.stat_info_typ_var = tk.StringVar(self.out_frame)
-        self.stat_info_sw_var = tk.StringVar(self.out_frame)
-        self.stat_info_timer_var = tk.StringVar(self.out_frame)
-        self.stat_info_encoding_var = tk.StringVar(self.out_frame)
-        self.stat_info_status_var = tk.StringVar(self.out_frame)
+        self.stat_info_name_var = tk.StringVar(self._out_frame)
+        self.stat_info_qth_var = tk.StringVar(self._out_frame)
+        self.stat_info_loc_var = tk.StringVar(self._out_frame)
+        self.stat_info_typ_var = tk.StringVar(self._out_frame)
+        self.stat_info_sw_var = tk.StringVar(self._out_frame)
+        self.stat_info_timer_var = tk.StringVar(self._out_frame)
+        self.stat_info_encoding_var = tk.StringVar(self._out_frame)
+        self.stat_info_status_var = tk.StringVar(self._out_frame)
         size = 0
-        name_label = tk.Label(self.out_frame,
+        name_label = tk.Label(self._out_frame,
                               textvariable=self.stat_info_name_var,
                               # bg=STAT_BAR_CLR,
                               height=1,
@@ -1115,7 +1115,7 @@ class TxTframe:
                               )
         name_label.grid(row=1, column=1, sticky="nsew")
         name_label.bind('<Button-1>', self._main_class.open_user_db_win)
-        qth_label = tk.Label(self.out_frame,
+        qth_label = tk.Label(self._out_frame,
                              textvariable=self.stat_info_qth_var,
                              bg=STAT_BAR_CLR,
                              fg=STAT_BAR_TXT_CLR,
@@ -1126,7 +1126,7 @@ class TxTframe:
                              )
         qth_label.bind('<Button-1>', self._main_class.open_user_db_win)
         qth_label.grid(row=1, column=2, sticky="nsew")
-        loc_label = tk.Label(self.out_frame,
+        loc_label = tk.Label(self._out_frame,
                              textvariable=self.stat_info_loc_var,
                              bg=STAT_BAR_CLR,
                              fg=STAT_BAR_TXT_CLR,
@@ -1140,7 +1140,7 @@ class TxTframe:
 
         opt = list(STATION_TYPS)
         stat_typ = tk.OptionMenu(
-            self.out_frame,
+            self._out_frame,
             self.stat_info_typ_var,
             *opt,
             command=self.set_stat_typ
@@ -1156,7 +1156,7 @@ class TxTframe:
         )
         stat_typ.grid(row=1, column=4, sticky="nsew")
 
-        tk.Label(self.out_frame,
+        tk.Label(self._out_frame,
                  textvariable=self.stat_info_sw_var,
                  width=20,
                  bg="#ffd444",
@@ -1167,7 +1167,7 @@ class TxTframe:
                  font=(FONT_STAT_BAR, TEXT_SIZE_STATUS - size)
                  ).grid(row=1, column=5, sticky="nsew")
 
-        self.status_label = tk.Label(self.out_frame,
+        self.status_label = tk.Label(self._out_frame,
                                      textvariable=self.stat_info_status_var,
                                      bg=STAT_BAR_CLR,
                                      fg="red3",
@@ -1179,7 +1179,7 @@ class TxTframe:
         self.status_label.grid(row=1, column=6, sticky="nsew")
         self.status_label.bind('<Button-1>', self._main_class.do_priv)
 
-        tk.Label(self.out_frame,
+        tk.Label(self._out_frame,
                  textvariable=self.stat_info_timer_var,
                  width=10,
                  height=1,
@@ -1191,7 +1191,7 @@ class TxTframe:
                  ).grid(row=1, column=7, sticky="nsew")
         opt = ENCODINGS
         txt_encoding_ent = tk.OptionMenu(
-            self.out_frame,
+            self._out_frame,
             self.stat_info_encoding_var,
             *opt,
             command=self.change_txt_encoding
@@ -1207,10 +1207,10 @@ class TxTframe:
         txt_encoding_ent.grid(row=1, column=8, sticky="nsew", )
         #############
         # Monitor
-        self.mon_txt = scrolledtext.ScrolledText(self.pw,
+        self.mon_txt = scrolledtext.ScrolledText(self._pw,
                                                  background=TXT_BACKGROUND_CLR,
                                                  foreground=TXT_MON_CLR,
-                                                 font=(FONT, self.text_size),
+                                                 font=(FONT, self._text_size),
                                                  height=100,
                                                  width=82,
                                                  bd=0,
@@ -1222,15 +1222,15 @@ class TxTframe:
 
         # paned window
 
-        self.pw.add(self.status_frame, weight=1)
+        self._pw.add(self._status_frame, weight=1)
         # self.pw.paneconfig(self.status_frame, height=40)
-        self.pw.add(self.out_frame, weight=1)
+        self._pw.add(self._out_frame, weight=1)
 
-        self.pw.add(self.mon_txt, weight=1)
+        self._pw.add(self.mon_txt, weight=1)
 
         # place the panedwindow on the root window
-        self.pw.pack(fill=tk.BOTH, expand=True)
-        self.pw.grid(row=1, column=0, sticky="nsew")
+        self._pw.pack(fill=tk.BOTH, expand=True)
+        self._pw.grid(row=1, column=0, sticky="nsew")
 
     def update_status_win(self):
         station = self._main_class.get_conn(self._main_class.channel_index)
@@ -1313,20 +1313,20 @@ class TxTframe:
         # TODO Save Stretched Positions
         if self._main_class.mon_mode:
             try:
-                self.pw.remove(self.status_frame)
-                self.pw.remove(self.mon_txt)
+                self._pw.remove(self._status_frame)
+                self._pw.remove(self.mon_txt)
             except tk.TclError:
                 pass
-            self.pw.add(self.status_frame, weight=1)
-            self.pw.add(self.out_frame, weight=1)
-            self.pw.add(self.mon_txt, weight=1)
+            self._pw.add(self._status_frame, weight=1)
+            self._pw.add(self._out_frame, weight=1)
+            self._pw.add(self.mon_txt, weight=1)
             # self.pw.configure(height=837)
 
         else:
             # _pw_height = self.pw.winfo_height()
             # _mon_txt_height = self.mon_txt.winfo_height()
             # _out_txt_height = self.out_txt_win.winfo_height()
-            self.pw.remove(self.out_frame)
+            self._pw.remove(self._out_frame)
             # self.pw.configure(height=837)
 
     def chk_rx_beep(self):
@@ -1373,96 +1373,96 @@ class TxTframe:
 class ChBtnFrm:
     def __init__(self, main_win):
         self._main_class = main_win
-        self.ch_btn_blink_timer = time.time()
-        self.ch_btn_frame = tk.Frame(self._main_class.main_win, width=500, height=10)
+        self._ch_btn_blink_timer = time.time()
+        self._ch_btn_frame = tk.Frame(self._main_class.main_win, width=500, height=10)
         _btn_font = ("fixedsys", 8,)
-        self.ch_btn_frame.columnconfigure(1, minsize=50, weight=1)
-        self.ch_btn_frame.columnconfigure(2, minsize=50, weight=1)
-        self.ch_btn_frame.columnconfigure(3, minsize=50, weight=1)
-        self.ch_btn_frame.columnconfigure(4, minsize=50, weight=1)
-        self.ch_btn_frame.columnconfigure(5, minsize=50, weight=1)
-        self.ch_btn_frame.columnconfigure(6, minsize=50, weight=1)
-        self.ch_btn_frame.columnconfigure(7, minsize=50, weight=1)
-        self.ch_btn_frame.columnconfigure(8, minsize=50, weight=1)
-        self.ch_btn_frame.columnconfigure(9, minsize=50, weight=1)
-        self.ch_btn_frame.columnconfigure(10, minsize=50, weight=1)
+        self._ch_btn_frame.columnconfigure(1, minsize=50, weight=1)
+        self._ch_btn_frame.columnconfigure(2, minsize=50, weight=1)
+        self._ch_btn_frame.columnconfigure(3, minsize=50, weight=1)
+        self._ch_btn_frame.columnconfigure(4, minsize=50, weight=1)
+        self._ch_btn_frame.columnconfigure(5, minsize=50, weight=1)
+        self._ch_btn_frame.columnconfigure(6, minsize=50, weight=1)
+        self._ch_btn_frame.columnconfigure(7, minsize=50, weight=1)
+        self._ch_btn_frame.columnconfigure(8, minsize=50, weight=1)
+        self._ch_btn_frame.columnconfigure(9, minsize=50, weight=1)
+        self._ch_btn_frame.columnconfigure(10, minsize=50, weight=1)
         # self.ch_btn_frame.grid(row=1, column=1, sticky="nsew")
-        self.ch_1_var = tk.StringVar(self.ch_btn_frame)
-        self.ch_2_var = tk.StringVar(self.ch_btn_frame)
-        self.ch_3_var = tk.StringVar(self.ch_btn_frame)
-        self.ch_4_var = tk.StringVar(self.ch_btn_frame)
-        self.ch_5_var = tk.StringVar(self.ch_btn_frame)
-        self.ch_6_var = tk.StringVar(self.ch_btn_frame)
-        self.ch_7_var = tk.StringVar(self.ch_btn_frame)
-        self.ch_8_var = tk.StringVar(self.ch_btn_frame)
-        self.ch_9_var = tk.StringVar(self.ch_btn_frame)
-        self.ch_10_var = tk.StringVar(self.ch_btn_frame)
-        self.ch_1_var.set('1')
-        self.ch_2_var.set('2')
-        self.ch_3_var.set('3')
-        self.ch_4_var.set('4')
-        self.ch_5_var.set('5')
-        self.ch_6_var.set('6')
-        self.ch_7_var.set('7')
-        self.ch_8_var.set('8')
-        self.ch_9_var.set('9')
-        self.ch_10_var.set('10')
-        self.ch_button1 = tk.Button(self.ch_btn_frame, font=_btn_font, textvariable=self.ch_1_var, bg="red",
-                                    command=lambda: self._main_class.switch_channel(1))
-        self.ch_button2 = tk.Button(self.ch_btn_frame, font=_btn_font, textvariable=self.ch_2_var, bg="red",
-                                    command=lambda: self._main_class.switch_channel(2))
-        self.ch_button3 = tk.Button(self.ch_btn_frame, font=_btn_font, textvariable=self.ch_3_var, bg="red",
-                                    command=lambda: self._main_class.switch_channel(3))
-        self.ch_button4 = tk.Button(self.ch_btn_frame, font=_btn_font, textvariable=self.ch_4_var, bg="red",
-                                    command=lambda: self._main_class.switch_channel(4))
-        self.ch_button5 = tk.Button(self.ch_btn_frame, font=_btn_font, textvariable=self.ch_5_var, bg="red",
-                                    command=lambda: self._main_class.switch_channel(5))
-        self.ch_button6 = tk.Button(self.ch_btn_frame, font=_btn_font, textvariable=self.ch_6_var, bg="red",
-                                    command=lambda: self._main_class.switch_channel(6))
-        self.ch_button7 = tk.Button(self.ch_btn_frame, font=_btn_font, textvariable=self.ch_7_var, bg="red",
-                                    command=lambda: self._main_class.switch_channel(7))
-        self.ch_button8 = tk.Button(self.ch_btn_frame, font=_btn_font, textvariable=self.ch_8_var, bg="red",
-                                    command=lambda: self._main_class.switch_channel(8))
-        self.ch_button9 = tk.Button(self.ch_btn_frame, font=_btn_font, textvariable=self.ch_9_var, bg="red",
-                                    command=lambda: self._main_class.switch_channel(9))
-        self.ch_button10 = tk.Button(self.ch_btn_frame, font=_btn_font, textvariable=self.ch_10_var, bg="red",
-                                     command=lambda: self._main_class.switch_channel(10))
-        self.ch_button1.grid(row=1, column=1, sticky="nsew")
-        self.ch_button2.grid(row=1, column=2, sticky="nsew")
-        self.ch_button3.grid(row=1, column=3, sticky="nsew")
-        self.ch_button4.grid(row=1, column=4, sticky="nsew")
-        self.ch_button5.grid(row=1, column=5, sticky="nsew")
-        self.ch_button6.grid(row=1, column=6, sticky="nsew")
-        self.ch_button7.grid(row=1, column=7, sticky="nsew")
-        self.ch_button8.grid(row=1, column=8, sticky="nsew")
-        self.ch_button9.grid(row=1, column=9, sticky="nsew")
-        self.ch_button10.grid(row=1, column=10, sticky="nsew")
+        ch_1_var = tk.StringVar(self._ch_btn_frame)
+        ch_2_var = tk.StringVar(self._ch_btn_frame)
+        ch_3_var = tk.StringVar(self._ch_btn_frame)
+        ch_4_var = tk.StringVar(self._ch_btn_frame)
+        ch_5_var = tk.StringVar(self._ch_btn_frame)
+        ch_6_var = tk.StringVar(self._ch_btn_frame)
+        ch_7_var = tk.StringVar(self._ch_btn_frame)
+        ch_8_var = tk.StringVar(self._ch_btn_frame)
+        ch_9_var = tk.StringVar(self._ch_btn_frame)
+        ch_10_var = tk.StringVar(self._ch_btn_frame)
+        ch_1_var.set('1')
+        ch_2_var.set('2')
+        ch_3_var.set('3')
+        ch_4_var.set('4')
+        ch_5_var.set('5')
+        ch_6_var.set('6')
+        ch_7_var.set('7')
+        ch_8_var.set('8')
+        ch_9_var.set('9')
+        ch_10_var.set('10')
+        ch_button1 = tk.Button(self._ch_btn_frame, font=_btn_font, textvariable=ch_1_var, bg="red",
+                               command=lambda: self._main_class.switch_channel(1))
+        ch_button2 = tk.Button(self._ch_btn_frame, font=_btn_font, textvariable=ch_2_var, bg="red",
+                               command=lambda: self._main_class.switch_channel(2))
+        ch_button3 = tk.Button(self._ch_btn_frame, font=_btn_font, textvariable=ch_3_var, bg="red",
+                               command=lambda: self._main_class.switch_channel(3))
+        ch_button4 = tk.Button(self._ch_btn_frame, font=_btn_font, textvariable=ch_4_var, bg="red",
+                               command=lambda: self._main_class.switch_channel(4))
+        ch_button5 = tk.Button(self._ch_btn_frame, font=_btn_font, textvariable=ch_5_var, bg="red",
+                               command=lambda: self._main_class.switch_channel(5))
+        ch_button6 = tk.Button(self._ch_btn_frame, font=_btn_font, textvariable=ch_6_var, bg="red",
+                               command=lambda: self._main_class.switch_channel(6))
+        ch_button7 = tk.Button(self._ch_btn_frame, font=_btn_font, textvariable=ch_7_var, bg="red",
+                               command=lambda: self._main_class.switch_channel(7))
+        ch_button8 = tk.Button(self._ch_btn_frame, font=_btn_font, textvariable=ch_8_var, bg="red",
+                               command=lambda: self._main_class.switch_channel(8))
+        ch_button9 = tk.Button(self._ch_btn_frame, font=_btn_font, textvariable=ch_9_var, bg="red",
+                               command=lambda: self._main_class.switch_channel(9))
+        ch_button10 = tk.Button(self._ch_btn_frame, font=_btn_font, textvariable=ch_10_var, bg="red",
+                                command=lambda: self._main_class.switch_channel(10))
+        ch_button1.grid(row=1, column=1, sticky="nsew")
+        ch_button2.grid(row=1, column=2, sticky="nsew")
+        ch_button3.grid(row=1, column=3, sticky="nsew")
+        ch_button4.grid(row=1, column=4, sticky="nsew")
+        ch_button5.grid(row=1, column=5, sticky="nsew")
+        ch_button6.grid(row=1, column=6, sticky="nsew")
+        ch_button7.grid(row=1, column=7, sticky="nsew")
+        ch_button8.grid(row=1, column=8, sticky="nsew")
+        ch_button9.grid(row=1, column=9, sticky="nsew")
+        ch_button10.grid(row=1, column=10, sticky="nsew")
         self._con_btn_dict = {
-            1: self.ch_button1,
-            2: self.ch_button2,
-            3: self.ch_button3,
-            4: self.ch_button4,
-            5: self.ch_button5,
-            6: self.ch_button6,
-            7: self.ch_button7,
-            8: self.ch_button8,
-            9: self.ch_button9,
-            10: self.ch_button10,
+            1: ch_button1,
+            2: ch_button2,
+            3: ch_button3,
+            4: ch_button4,
+            5: ch_button5,
+            6: ch_button6,
+            7: ch_button7,
+            8: ch_button8,
+            9: ch_button9,
+            10: ch_button10,
         }
         self._ch_btn_textvar = {
-            1: self.ch_1_var,
-            2: self.ch_2_var,
-            3: self.ch_3_var,
-            4: self.ch_4_var,
-            5: self.ch_5_var,
-            6: self.ch_6_var,
-            7: self.ch_7_var,
-            8: self.ch_8_var,
-            9: self.ch_9_var,
-            10: self.ch_10_var,
+            1: ch_1_var,
+            2: ch_2_var,
+            3: ch_3_var,
+            4: ch_4_var,
+            5: ch_5_var,
+            6: ch_6_var,
+            7: ch_7_var,
+            8: ch_8_var,
+            9: ch_9_var,
+            10: ch_10_var,
         }
 
-    def ch_btn_status_update(self):
+    def _ch_btn_status_update(self):
         # self.main_class.on_channel_status_change()
         _ch_alarm = False
         # if PORT_HANDLER.get_all_connections().keys():
@@ -1501,8 +1501,8 @@ class ChBtnFrm:
                             _ch_alarm = False
                         else:
                             _ch_alarm = True
-                            if self.ch_btn_blink_timer < time.time():
-                                self.ch_btn_alarm(self._con_btn_dict[i])
+                            if self._ch_btn_blink_timer < time.time():
+                                self._ch_btn_alarm(self._con_btn_dict[i])
                     else:
                         if _is_link:
                             _ch_alarm = False
@@ -1531,17 +1531,15 @@ class ChBtnFrm:
                     if self._con_btn_dict[i].cget('bg') != 'yellow':
                         self._con_btn_dict[i].configure(bg='yellow')
 
-        if self.ch_btn_blink_timer < time.time():
-            self.ch_btn_blink_timer = time.time() + self._main_class.parm_btn_blink_time
+        if self._ch_btn_blink_timer < time.time():
+            self._ch_btn_blink_timer = time.time() + self._main_class.parm_btn_blink_time
         self._main_class.ch_alarm = _ch_alarm
 
-    def ch_btn_alarm(self, btn: tk.Button):
-        # TODO find another solution
-        if self.ch_btn_blink_timer < time.time():
+    def _ch_btn_alarm(self, btn: tk.Button):
+        if self._ch_btn_blink_timer < time.time():
             _clr = generate_random_hex_color()
             if btn.cget('bg') != _clr:
                 btn.configure(bg=_clr)
-            # self.ch_btn_blink_timer = time.time() + self.main_class.parm_btn_blink_time
 
 
 class TkMainWin:
@@ -1600,7 +1598,7 @@ class TkMainWin:
         #########################
         # Channel Buttons
         self._ch_btn = ChBtnFrm(self)
-        self._ch_btn.ch_btn_frame.grid(row=2, column=0, columnspan=1, sticky="nsew")
+        self._ch_btn._ch_btn_frame.grid(row=2, column=0, columnspan=1, sticky="nsew")
         #########################
         # Tabbed Frame right
         self._side_btn_frame_top = tk.Frame(self.main_win, width=200, height=540)
@@ -2919,7 +2917,7 @@ class TkMainWin:
     def ch_status_update(self):
         """ Triggered by tasker !!! """
         """Triggerd when Connection Status has changed"""
-        self._ch_btn.ch_btn_status_update()
+        self._ch_btn._ch_btn_status_update()
         # self.change_conn_btn()
         self.on_channel_status_change()
 
@@ -2964,7 +2962,7 @@ class TkMainWin:
             self._txt_win.ts_box_box.configure(bg=STAT_BAR_CLR)
 
         self.on_channel_status_change()
-        self._ch_btn.ch_btn_status_update()
+        self._ch_btn._ch_btn_status_update()
         self._kanal_switch()  # Sprech
 
     def on_channel_status_change(self):
@@ -3157,4 +3155,3 @@ class TkMainWin:
 
     def get_dx_alarm(self):
         return bool(self.setting_dx_alarm.get())
-

--- a/gui/guiMain.py
+++ b/gui/guiMain.py
@@ -321,6 +321,7 @@ class SideTabbedFrame:
         columns = (
             'mh_last_seen',
             'mh_call',
+            'mh_dist',
             'mh_port',
             'mh_nPackets',
             'mh_route',
@@ -331,14 +332,16 @@ class SideTabbedFrame:
 
         self._tree.heading('mh_last_seen', text='Zeit')
         self._tree.heading('mh_call', text='Call')
+        self._tree.heading('mh_dist', text='km')
         self._tree.heading('mh_port', text='Port')
         self._tree.heading('mh_nPackets', text='PACK')
         self._tree.heading('mh_route', text='Route')
-        self._tree.column("mh_last_seen", anchor=tk.CENTER, stretch=tk.NO, width=90)
-        self._tree.column("mh_call", stretch=tk.NO, width=100)
-        self._tree.column("mh_port", anchor=tk.CENTER, stretch=tk.NO, width=80)
-        self._tree.column("mh_nPackets", anchor=tk.CENTER, stretch=tk.NO, width=60)
-        self._tree.column("mh_route", stretch=tk.YES, width=180)
+        self._tree.column("mh_last_seen", anchor=tk.W, stretch=tk.NO, width=85)
+        self._tree.column("mh_call", anchor=tk.W, stretch=tk.NO, width=105)
+        self._tree.column("mh_dist", anchor=tk.CENTER, stretch=tk.NO, width=70)
+        self._tree.column("mh_port", anchor=tk.W, stretch=tk.NO, width=61)
+        self._tree.column("mh_nPackets", anchor=tk.W, stretch=tk.NO, width=60)
+        self._tree.column("mh_route", anchor=tk.W, stretch=tk.YES, width=180)
 
         self._tree_data = []
         self._last_mh_ent = []
@@ -731,7 +734,7 @@ class SideTabbedFrame:
             record = item['values']
             # show a message
             call = record[1]
-            vias = record[4]
+            vias = record[5]
             port = record[2]
             port = int(port.split(' ')[0])
             if vias:
@@ -758,6 +761,7 @@ class SideTabbedFrame:
             self._tree_data.append((
                 f"{conv_time_DE_str(ent.last_seen).split(' ')[1]}",
                 f'{ent.own_call}',
+                f'{ent.distance}',
                 f'{ent.port_id} {ent.port}',
                 f'{ent.pac_n}',
                 ' '.join(route),

--- a/gui/guiMain.py
+++ b/gui/guiMain.py
@@ -983,58 +983,80 @@ class TxTframe:
         self.in_txt_win.grid(row=0, column=0, columnspan=12, sticky="nsew")
         ##############
         # Status Frame
-        self.status_name = Label(self._status_frame, text="", font=(FONT_STAT_BAR, TEXT_SIZE_STATUS),
-                                 foreground=STAT_BAR_TXT_CLR,
-                                 bg=STAT_BAR_CLR)
-        self.status_name.grid(row=1, column=1, sticky="nsew")
+        self.status_name_var = tk.StringVar(self._status_frame)
+        self.status_status_var = tk.StringVar(self._status_frame)
+        self.status_unack_var = tk.StringVar(self._status_frame)
+        self.status_vs_var = tk.StringVar(self._status_frame)
+        self.status_n2_var = tk.StringVar(self._status_frame)
+        self.status_t1_var = tk.StringVar(self._status_frame)
+        self.status_t2_var = tk.StringVar(self._status_frame)
+        self.status_rtt_var = tk.StringVar(self._status_frame)
+        self.status_t3_var = tk.StringVar(self._status_frame)
+        Label(self._status_frame,
+              textvariable=self.status_name_var,
+              font=(FONT_STAT_BAR, TEXT_SIZE_STATUS),
+              foreground=STAT_BAR_TXT_CLR,
+              bg=STAT_BAR_CLR
+              ).grid(row=1, column=1, sticky="nsew")
 
-        self.status_status = Label(self._status_frame, text="",
+        self.status_status = Label(self._status_frame,
+                                   textvariable=self.status_status_var,
                                    font=(FONT_STAT_BAR, TEXT_SIZE_STATUS),
                                    bg=STAT_BAR_CLR,
-                                   foreground=STAT_BAR_TXT_CLR)
+                                   foreground=STAT_BAR_TXT_CLR
+                                   )
         self.status_status.grid(row=1, column=2, sticky="nsew")
 
-        self.status_unack = Label(self._status_frame, text="",
+        self.status_unack = Label(self._status_frame,
+                                  textvariable=self.status_unack_var,
                                   foreground=STAT_BAR_TXT_CLR,
                                   font=(FONT_STAT_BAR, TEXT_SIZE_STATUS),
-                                  bg=STAT_BAR_CLR)
+                                  bg=STAT_BAR_CLR
+                                  )
         self.status_unack.grid(row=1, column=3, sticky="nsew")
 
-        self.status_vs = Label(self._status_frame, text="",
-                               font=(FONT_STAT_BAR, TEXT_SIZE_STATUS),
-                               bg=STAT_BAR_CLR,
-                               foreground=STAT_BAR_TXT_CLR)
-        self.status_vs.grid(row=1, column=4, sticky="nsew")
+        Label(self._status_frame,
+              textvariable=self.status_vs_var,
+              font=(FONT_STAT_BAR, TEXT_SIZE_STATUS),
+              bg=STAT_BAR_CLR,
+              foreground=STAT_BAR_TXT_CLR
+              ).grid(row=1, column=4, sticky="nsew")
 
-        self.status_n2 = Label(self._status_frame, text="",
+        self.status_n2 = Label(self._status_frame,
+                               textvariable=self.status_n2_var,
                                font=(FONT_STAT_BAR, TEXT_SIZE_STATUS),
                                bg=STAT_BAR_CLR,
-                               foreground=STAT_BAR_TXT_CLR)
+                               foreground=STAT_BAR_TXT_CLR
+                               )
         self.status_n2.grid(row=1, column=7, sticky="nsew")
 
-        self.status_t1 = Label(self._status_frame, text="",
-                               font=(FONT_STAT_BAR, TEXT_SIZE_STATUS),
-                               bg=STAT_BAR_CLR,
-                               foreground=STAT_BAR_TXT_CLR)
-        self.status_t1.grid(row=1, column=8, sticky="nsew")
+        Label(self._status_frame,
+              textvariable=self.status_t1_var,
+              font=(FONT_STAT_BAR, TEXT_SIZE_STATUS),
+              bg=STAT_BAR_CLR,
+              foreground=STAT_BAR_TXT_CLR
+              ).grid(row=1, column=8, sticky="nsew")
         # PARM T2
-        self.status_t2 = Label(self._status_frame, text="",
-                               font=(FONT_STAT_BAR, TEXT_SIZE_STATUS),
-                               bg=STAT_BAR_CLR,
-                               foreground=STAT_BAR_TXT_CLR)
-        self.status_t2.grid(row=1, column=5, sticky="nsew")
+        Label(self._status_frame,
+              textvariable=self.status_t2_var,
+              font=(FONT_STAT_BAR, TEXT_SIZE_STATUS),
+              bg=STAT_BAR_CLR,
+              foreground=STAT_BAR_TXT_CLR
+              ).grid(row=1, column=5, sticky="nsew")
         # RTT
-        self.status_rtt = Label(self._status_frame, text="",
-                                font=(FONT_STAT_BAR, TEXT_SIZE_STATUS),
-                                bg=STAT_BAR_CLR,
-                                foreground=STAT_BAR_TXT_CLR)
-        self.status_rtt.grid(row=1, column=6, sticky="nsew")
+        Label(self._status_frame,
+              textvariable=self.status_rtt_var,
+              font=(FONT_STAT_BAR, TEXT_SIZE_STATUS),
+              bg=STAT_BAR_CLR,
+              foreground=STAT_BAR_TXT_CLR
+              ).grid(row=1, column=6, sticky="nsew")
 
-        self.status_t3 = Label(self._status_frame, text="",
-                               font=(FONT_STAT_BAR, TEXT_SIZE_STATUS),
-                               bg=STAT_BAR_CLR,
-                               foreground=STAT_BAR_TXT_CLR)
-        self.status_t3.grid(row=1, column=9, sticky="nsew")
+        Label(self._status_frame,
+              textvariable=self.status_t3_var,
+              font=(FONT_STAT_BAR, TEXT_SIZE_STATUS),
+              bg=STAT_BAR_CLR,
+              foreground=STAT_BAR_TXT_CLR
+              ).grid(row=1, column=9, sticky="nsew")
         # Checkbox RX-BEEP
         self.rx_beep_var = tk.IntVar()
         self.rx_beep_box = Checkbutton(self._status_frame,
@@ -1046,7 +1068,7 @@ class TxTframe:
                                        onvalue=1, offvalue=0,
                                        foreground=STAT_BAR_TXT_CLR,
                                        variable=self.rx_beep_var,
-                                       command=self.chk_rx_beep
+                                       command=self._chk_rx_beep
                                        )
         self.rx_beep_box.grid(row=1, column=10, sticky="nsew")
         # TODO Checkbox Time Stamp
@@ -1143,7 +1165,7 @@ class TxTframe:
             self._out_frame,
             self.stat_info_typ_var,
             *opt,
-            command=self.set_stat_typ
+            command=self._set_stat_typ
         )
         stat_typ.configure(
             background="#0ed8c3",
@@ -1194,7 +1216,7 @@ class TxTframe:
             self._out_frame,
             self.stat_info_encoding_var,
             *opt,
-            command=self.change_txt_encoding
+            command=self._change_txt_encoding
         )
         txt_encoding_ent.configure(
             background="steel blue",
@@ -1236,10 +1258,12 @@ class TxTframe:
         station = self._main_class.get_conn(self._main_class.channel_index)
         if station:
             _from_call = station.ax25_out_frame.from_call.call_str
+            """
             _via_calls = ''
             for _via in station.ax25_out_frame.via_calls:
                 # via: Call
                 _via_calls += _via.call_str + ' '
+            """
             _status = station.zustand_tab[station.zustand_exec.stat_index][1]
             # uid = station.ax25_out_frame.addr_uid
             _n2 = station.n2
@@ -1253,61 +1277,57 @@ class TxTframe:
                 _t2_text = f"T2: {int(station.parm_T2 * 1000)}A"
             else:
                 _t2_text = f"T2: {int(station.parm_T2 * 1000)}"
-
-            if self.status_name.cget('text') != _from_call:
-                self.status_name.configure(text=_from_call)
-            if self.status_status.cget('text') != _status:
+            if self.status_name_var.get() != _from_call:
+                self.status_name_var.set(_from_call)
+            if self.status_status_var.get() != _status:
                 _status_bg = STATUS_BG[_status]
-                self.status_status.configure(text=_status, bg=_status_bg)
-
-            if len(station.tx_buf_unACK.keys()):
-                if self.status_unack.cget('bg') != 'yellow':
-                    self.status_unack.configure(bg='yellow')
-            else:
-                if self.status_unack.cget('bg') != 'green':
-                    self.status_unack.configure(bg='green')
-            if self.status_unack.cget('text') != _unAck:
-                self.status_unack.configure(text=_unAck)
-
-            if self.status_vs.cget('text') != _vs_vr:
-                self.status_vs.configure(text=_vs_vr)
-
-            if _n2 > 4:
-                if self.status_n2.cget('bg') != 'yellow':
-                    self.status_n2.configure(bg='yellow')
-            elif _n2 > 10:
-                if self.status_n2.cget('bg') != 'orange':
-                    self.status_n2.configure(bg='orange')
-            else:
-                if self.status_n2.cget('bg') != STAT_BAR_CLR:
-                    self.status_n2.configure(bg=STAT_BAR_CLR)
-
-            if self.status_n2.cget('text') != _n2_text:
-                self.status_n2.configure(text=_n2_text)
-
-            if self.status_t1.cget('text') != _t1_text:
-                self.status_t1.configure(text=_t1_text)
-
-            if self.status_t2.cget('text') != _t2_text:
-                self.status_t2.configure(text=_t2_text)
-
-            if self.status_rtt.cget('text') != _rtt_text:
-                self.status_rtt.configure(text=_rtt_text)
-
-            if self.status_t3.cget('text') != _t3_text:
-                self.status_t3.configure(text=_t3_text)
+                self.status_status_var.set(_status)
+                self.status_status.configure(bg=_status_bg)
+            if self.status_unack_var.get() != _unAck:
+                self.status_unack_var.set(_unAck)
+                if len(station.tx_buf_unACK.keys()):
+                    if self.status_unack.cget('bg') != 'yellow':
+                        self.status_unack.configure(bg='yellow')
+                else:
+                    if self.status_unack.cget('bg') != 'green':
+                        self.status_unack.configure(bg='green')
+            if self.status_vs_var.get() != _vs_vr:
+                self.status_vs_var.set(_vs_vr)
+            if self.status_n2_var.get() != _n2_text:
+                self.status_n2_var.set(_n2_text)
+                if _n2 > 4:
+                    if self.status_n2.cget('bg') != 'yellow':
+                        self.status_n2.configure(bg='yellow')
+                elif _n2 > 10:
+                    if self.status_n2.cget('bg') != 'orange':
+                        self.status_n2.configure(bg='orange')
+                else:
+                    if self.status_n2.cget('bg') != STAT_BAR_CLR:
+                        self.status_n2.configure(bg=STAT_BAR_CLR)
+            if self.status_t1_var.get() != _t1_text:
+                self.status_t1_var.set(_t1_text)
+            if self.status_t2_var.get() != _t2_text:
+                self.status_t2_var.set(_t2_text)
+            if self.status_rtt_var.get() != _rtt_text:
+                self.status_rtt_var.set(_rtt_text)
+            if self.status_t3_var.get() != _t3_text:
+                self.status_t3_var.set(_t3_text)
 
         else:
             if self.status_status.cget('text') or self.status_status.cget('bg') != STAT_BAR_CLR:
-                self.status_name.configure(text="", bg=STAT_BAR_CLR)
-                self.status_status.configure(text="", bg=STAT_BAR_CLR)
-                self.status_unack.configure(text="", bg=STAT_BAR_CLR)
-                self.status_vs.configure(text="", bg=STAT_BAR_CLR)
-                self.status_n2.configure(text="", bg=STAT_BAR_CLR)
-                self.status_t1.configure(text="", bg=STAT_BAR_CLR)
-                self.status_t2.configure(text="", bg=STAT_BAR_CLR)
-                self.status_t3.configure(text="", bg=STAT_BAR_CLR)
-                self.status_rtt.configure(text="", bg=STAT_BAR_CLR)
+                # self.status_name.configure(text="", bg=STAT_BAR_CLR)
+                self.status_name_var.set('')
+                self.status_status.configure(bg=STAT_BAR_CLR)
+                self.status_status_var.set('')
+                self.status_unack.configure(bg=STAT_BAR_CLR)
+                self.status_unack_var.set('')
+                self.status_vs_var.set('')
+                self.status_n2.configure(bg=STAT_BAR_CLR)
+                self.status_n2_var.set('')
+                self.status_t1_var.set('')
+                self.status_t2_var.set('')
+                self.status_t3_var.set('')
+                self.status_rtt_var.set('')
 
     def switch_mon_mode(self):
         # TODO Save Stretched Positions
@@ -1329,7 +1349,7 @@ class TxTframe:
             self._pw.remove(self._out_frame)
             # self.pw.configure(height=837)
 
-    def chk_rx_beep(self):
+    def _chk_rx_beep(self):
         _rx_beep_check = self.rx_beep_var.get()
         if _rx_beep_check:
             if self.rx_beep_box.cget('bg') != 'green':
@@ -1349,7 +1369,7 @@ class TxTframe:
                 self.ts_box_box.configure(bg=STAT_BAR_CLR, activebackground=STAT_BAR_CLR)
         self._main_class.get_ch_param().timestamp_opt = _ts_check
 
-    def set_stat_typ(self, event=None):
+    def _set_stat_typ(self, event=None):
         conn = self._main_class.get_conn()
         if conn:
             db_ent = conn.user_db_ent
@@ -1358,7 +1378,7 @@ class TxTframe:
         else:
             self.stat_info_typ_var.set('-----')
 
-    def change_txt_encoding(self, event=None, enc=''):
+    def _change_txt_encoding(self, event=None, enc=''):
         conn = self._main_class.get_conn()
         if conn:
             db_ent = conn.user_db_ent
@@ -1374,29 +1394,30 @@ class ChBtnFrm:
     def __init__(self, main_win):
         self._main_class = main_win
         self._ch_btn_blink_timer = time.time()
-        self._ch_btn_frame = tk.Frame(self._main_class.main_win, width=500, height=10)
+        _ch_btn_frame = tk.Frame(self._main_class.main_win, width=500, height=10)
+        _ch_btn_frame.grid(row=2, column=0, columnspan=1, sticky="nsew")
         _btn_font = ("fixedsys", 8,)
-        self._ch_btn_frame.columnconfigure(1, minsize=50, weight=1)
-        self._ch_btn_frame.columnconfigure(2, minsize=50, weight=1)
-        self._ch_btn_frame.columnconfigure(3, minsize=50, weight=1)
-        self._ch_btn_frame.columnconfigure(4, minsize=50, weight=1)
-        self._ch_btn_frame.columnconfigure(5, minsize=50, weight=1)
-        self._ch_btn_frame.columnconfigure(6, minsize=50, weight=1)
-        self._ch_btn_frame.columnconfigure(7, minsize=50, weight=1)
-        self._ch_btn_frame.columnconfigure(8, minsize=50, weight=1)
-        self._ch_btn_frame.columnconfigure(9, minsize=50, weight=1)
-        self._ch_btn_frame.columnconfigure(10, minsize=50, weight=1)
+        _ch_btn_frame.columnconfigure(1, minsize=50, weight=1)
+        _ch_btn_frame.columnconfigure(2, minsize=50, weight=1)
+        _ch_btn_frame.columnconfigure(3, minsize=50, weight=1)
+        _ch_btn_frame.columnconfigure(4, minsize=50, weight=1)
+        _ch_btn_frame.columnconfigure(5, minsize=50, weight=1)
+        _ch_btn_frame.columnconfigure(6, minsize=50, weight=1)
+        _ch_btn_frame.columnconfigure(7, minsize=50, weight=1)
+        _ch_btn_frame.columnconfigure(8, minsize=50, weight=1)
+        _ch_btn_frame.columnconfigure(9, minsize=50, weight=1)
+        _ch_btn_frame.columnconfigure(10, minsize=50, weight=1)
         # self.ch_btn_frame.grid(row=1, column=1, sticky="nsew")
-        ch_1_var = tk.StringVar(self._ch_btn_frame)
-        ch_2_var = tk.StringVar(self._ch_btn_frame)
-        ch_3_var = tk.StringVar(self._ch_btn_frame)
-        ch_4_var = tk.StringVar(self._ch_btn_frame)
-        ch_5_var = tk.StringVar(self._ch_btn_frame)
-        ch_6_var = tk.StringVar(self._ch_btn_frame)
-        ch_7_var = tk.StringVar(self._ch_btn_frame)
-        ch_8_var = tk.StringVar(self._ch_btn_frame)
-        ch_9_var = tk.StringVar(self._ch_btn_frame)
-        ch_10_var = tk.StringVar(self._ch_btn_frame)
+        ch_1_var = tk.StringVar(_ch_btn_frame)
+        ch_2_var = tk.StringVar(_ch_btn_frame)
+        ch_3_var = tk.StringVar(_ch_btn_frame)
+        ch_4_var = tk.StringVar(_ch_btn_frame)
+        ch_5_var = tk.StringVar(_ch_btn_frame)
+        ch_6_var = tk.StringVar(_ch_btn_frame)
+        ch_7_var = tk.StringVar(_ch_btn_frame)
+        ch_8_var = tk.StringVar(_ch_btn_frame)
+        ch_9_var = tk.StringVar(_ch_btn_frame)
+        ch_10_var = tk.StringVar(_ch_btn_frame)
         ch_1_var.set('1')
         ch_2_var.set('2')
         ch_3_var.set('3')
@@ -1407,25 +1428,25 @@ class ChBtnFrm:
         ch_8_var.set('8')
         ch_9_var.set('9')
         ch_10_var.set('10')
-        ch_button1 = tk.Button(self._ch_btn_frame, font=_btn_font, textvariable=ch_1_var, bg="red",
+        ch_button1 = tk.Button(_ch_btn_frame, font=_btn_font, textvariable=ch_1_var, bg="red",
                                command=lambda: self._main_class.switch_channel(1))
-        ch_button2 = tk.Button(self._ch_btn_frame, font=_btn_font, textvariable=ch_2_var, bg="red",
+        ch_button2 = tk.Button(_ch_btn_frame, font=_btn_font, textvariable=ch_2_var, bg="red",
                                command=lambda: self._main_class.switch_channel(2))
-        ch_button3 = tk.Button(self._ch_btn_frame, font=_btn_font, textvariable=ch_3_var, bg="red",
+        ch_button3 = tk.Button(_ch_btn_frame, font=_btn_font, textvariable=ch_3_var, bg="red",
                                command=lambda: self._main_class.switch_channel(3))
-        ch_button4 = tk.Button(self._ch_btn_frame, font=_btn_font, textvariable=ch_4_var, bg="red",
+        ch_button4 = tk.Button(_ch_btn_frame, font=_btn_font, textvariable=ch_4_var, bg="red",
                                command=lambda: self._main_class.switch_channel(4))
-        ch_button5 = tk.Button(self._ch_btn_frame, font=_btn_font, textvariable=ch_5_var, bg="red",
+        ch_button5 = tk.Button(_ch_btn_frame, font=_btn_font, textvariable=ch_5_var, bg="red",
                                command=lambda: self._main_class.switch_channel(5))
-        ch_button6 = tk.Button(self._ch_btn_frame, font=_btn_font, textvariable=ch_6_var, bg="red",
+        ch_button6 = tk.Button(_ch_btn_frame, font=_btn_font, textvariable=ch_6_var, bg="red",
                                command=lambda: self._main_class.switch_channel(6))
-        ch_button7 = tk.Button(self._ch_btn_frame, font=_btn_font, textvariable=ch_7_var, bg="red",
+        ch_button7 = tk.Button(_ch_btn_frame, font=_btn_font, textvariable=ch_7_var, bg="red",
                                command=lambda: self._main_class.switch_channel(7))
-        ch_button8 = tk.Button(self._ch_btn_frame, font=_btn_font, textvariable=ch_8_var, bg="red",
+        ch_button8 = tk.Button(_ch_btn_frame, font=_btn_font, textvariable=ch_8_var, bg="red",
                                command=lambda: self._main_class.switch_channel(8))
-        ch_button9 = tk.Button(self._ch_btn_frame, font=_btn_font, textvariable=ch_9_var, bg="red",
+        ch_button9 = tk.Button(_ch_btn_frame, font=_btn_font, textvariable=ch_9_var, bg="red",
                                command=lambda: self._main_class.switch_channel(9))
-        ch_button10 = tk.Button(self._ch_btn_frame, font=_btn_font, textvariable=ch_10_var, bg="red",
+        ch_button10 = tk.Button(_ch_btn_frame, font=_btn_font, textvariable=ch_10_var, bg="red",
                                 command=lambda: self._main_class.switch_channel(10))
         ch_button1.grid(row=1, column=1, sticky="nsew")
         ch_button2.grid(row=1, column=2, sticky="nsew")
@@ -1598,7 +1619,7 @@ class TkMainWin:
         #########################
         # Channel Buttons
         self._ch_btn = ChBtnFrm(self)
-        self._ch_btn._ch_btn_frame.grid(row=2, column=0, columnspan=1, sticky="nsew")
+        # self._ch_btn._ch_btn_frame.grid(row=2, column=0, columnspan=1, sticky="nsew")
         #########################
         # Tabbed Frame right
         self._side_btn_frame_top = tk.Frame(self.main_win, width=200, height=540)
@@ -1704,7 +1725,8 @@ class TkMainWin:
         self._parm_rx_beep_cooldown = 2  # s
         # Tasker Timings
         self._loop_delay = 250  # ms
-        self._parm_non_prio_task_timer = 0.5  # s
+        self._parm_non_prio_task_timer = 0.25  # s
+        self._prio_task_flip = True
         self._parm_non_non_prio_task_timer = 1  # s
         self._parm_non_non_non_prio_task_timer = 5  # s
         self._parm_test_task_timer = 60  # 5        # s
@@ -2318,12 +2340,12 @@ class TkMainWin:
         if self._is_closing:
             self._tasker_quit()
         else:
-            # self._tasker_prio()
-            self._tasker_05_sec()
+            self._tasker_prio()
+            # self._tasker_05_sec()
             self._tasker_1_sec()
             self._tasker_5_sec()
             # self._tasker_tester()
-            self.main_win.update_idletasks()
+            # self.main_win.update_idletasks()
         self.main_win.after(self._loop_delay, self._tasker)
 
     @staticmethod
@@ -2333,23 +2355,26 @@ class TkMainWin:
             logging.info('Closing GUI: Done.')
 
     def _tasker_prio(self):
-        """ Prio Tasks """
-        pass
-
-    def _tasker_05_sec(self):
-        """ 0.5 Sec """
-        if time.time() > self._non_prio_task_timer:
-            self._non_prio_task_timer = time.time() + self._parm_non_prio_task_timer
-            #####################
+        """ Prio Tasks 250 ms each flip """
+        if self._prio_task_flip:
             self._aprs_task()
             self._monitor_task()
             self._update_qso_win()
+        else:
             self._txt_win.update_status_win()
             self.change_conn_btn()
             if self.setting_sound:
                 self._rx_beep_sound()
                 if self.setting_sprech:
                     self._check_sprech_ch_buf()
+        self._prio_task_flip = not self._prio_task_flip
+
+    def _tasker_05_sec(self):
+        """ 0.5 Sec """
+        if time.time() > self._non_prio_task_timer:
+            self._non_prio_task_timer = time.time() + self._parm_non_prio_task_timer
+            #####################
+            pass
 
     def _tasker_1_sec(self):
         """ 1 Sec """

--- a/gui/guiMain.py
+++ b/gui/guiMain.py
@@ -1563,6 +1563,21 @@ class TkMainWin:
         ######################################
         # Init Vars
         self._init_vars()
+        ###############
+        self.text_size = 14
+        ############################
+        # Windows
+        self.new_conn_win = None
+        self.settings_win = None
+        self.mh_window = None
+        self.wx_window = None
+        self.port_stat_win = None
+        self.be_tracer_win = None
+        self.locator_calc_window = None
+        self.aprs_mon_win = None
+        self.aprs_pn_msg_win = None
+        self.userdb_win = None
+        self.userDB_tree_win = None
         ######################################
         # ....
         self.main_win.columnconfigure(0, minsize=500, weight=1)
@@ -1667,7 +1682,6 @@ class TkMainWin:
         self._root_dir = get_root_dir()
         self._root_dir = self._root_dir.replace('/', '//')
         #####################
-        #####################
         # GUI VARS
         self.connect_history = {}
         # GLb Setting Vars
@@ -1700,21 +1714,6 @@ class TkMainWin:
         self._non_non_prio_task_timer = time.time()
         self._non_non_non_prio_task_timer = time.time()
         self._test_task_timer = time.time()
-        ###############
-        self.text_size = 14
-        ############################
-        # Windows
-        self.new_conn_win = None
-        self.settings_win = None
-        self.mh_window = None
-        self.wx_window = None
-        self.port_stat_win = None
-        self.be_tracer_win = None
-        self.locator_calc_window = None
-        self.aprs_mon_win = None
-        self.aprs_pn_msg_win = None
-        self.userdb_win = None
-        self.userDB_tree_win = None
         ##############################
         # BW-Plot
         self._bw_plot_x_scale = []
@@ -1739,27 +1738,23 @@ class TkMainWin:
         MH_LIST.parm_lastseen_alarm = 1
 
     def _init_bw_plot(self):
-        # plt.ion()
         self._bw_fig = Figure(figsize=(8, 5), dpi=80)
         # plt.style.use('dark_background')
         self._ax = self._bw_fig.add_subplot(111)
         self._bw_fig.subplots_adjust(left=0.1, right=0.95, top=0.99, bottom=0.1)
-        self._ax.axis([0, 10, 0, 100])
+        self._ax.axis([0, 10, 0, 100])  # TODO As Option
         self._bw_fig.set_facecolor('xkcd:light grey')
         self._ax.set_facecolor('#000000')
-        # self.bw_fig.xlim(0, 10)  # TODO As Option
         self._ax.xaxis.label.set_color('black')
         self._ax.yaxis.label.set_color('black')
         self._ax.tick_params(axis='x', colors='black')
         self._ax.tick_params(axis='y', colors='black')
         self._ax.set_xlabel(STR_TABLE['minutes'][self.language])
         self._ax.set_ylabel(STR_TABLE['occup'][self.language])
-        # plt.xlim(0, 10)  # TODO As Option
-        self._canvas = FigureCanvasTkAgg(self._bw_fig, master=self._side_btn_frame_top)  # A tk.DrawingArea.
+        self._canvas = FigureCanvasTkAgg(self._bw_fig, master=self._side_btn_frame_top)
         self._canvas.flush_events()
         self._canvas.draw()
         self._canvas.get_tk_widget().grid(row=4, column=0, columnspan=7, sticky="nsew")
-        # self._canvas.get_tk_widget().pack(fill=tk.BOTH)
         # self._canvas.get_tk_widget().config(cursor="none")
         self._bw_fig.canvas.flush_events()
 

--- a/idea.txt
+++ b/idea.txt
@@ -2,6 +2,7 @@ Ideas/TODO's :
 
 - ESC Befehle
 - Individuelle Farben (Vorschreib Fenster)
+- Beacon System überarbeiten
 ✓ UserDB
 - Infos / Ctext usw. in User-DB speichern
 - User-DB Sync System (Manuell zu triggern bei connect zu anderer PoPT Station)

--- a/idea.txt
+++ b/idea.txt
@@ -11,6 +11,8 @@ Ideas/TODO's :
 - Debugging Tool
 - Simple Mailbox
 - BBS Tool was Bulletins und PMs von/an Heimat-BBS holt/sendet und Mails aufbereitet darstellt.
+- BBS (S&F und all den Gedöns)
+- "Nachrichten-Center" fasst alle Nachrichtenkanäle (APRS Bulletin/PN, BBS) übersichtlich zusammen.
 - Telnet Port
 - Loop Port oder einfach localhost via AXIP
 - MultiKISS
@@ -27,6 +29,7 @@ Ideas/TODO's :
 ✓ APRS Private Message System
 ✓ APRS Tracer
 ✓ APRS Tracer Alarm
+✓ APRS Auto-Tracer nach DX-Alarm(MH-Liste)
 ✓ APRS WX Stationen (Wetterstationen) Monitoring Auswertung
 - APRS Digi / I-Gate Funktion
 - "Managed-DIGI" Funktion (Die DIGI Verbindung wird wie ein Noden Link behandelt)
@@ -36,7 +39,7 @@ Ideas/TODO's :
 - Daten Komprimierung
 - Daten Verschlüsselung (AES/RSA)
 ✓ ordentliches Noden System bzw CLI überarbeiten
-- DX-Alarm überarbeiten
+✓ DX-Alarm überarbeiten
 ✓ Autoscrolling überarbeiten.
 - Optional nur als Konsolen Anwendung ohne GUI. (Ist bereits dafür vorbereitet)
 - Drucker Ausgabe vom QSO

--- a/string_tab.py
+++ b/string_tab.py
@@ -203,7 +203,7 @@ STR_TABLE = {
                       'Lekker Ports'),
     'cmd_shelp': ('Kurzhilfe',
                   'Short help',
-                  'Lekker Short Helpye'),
+                  'Lekker Korte hulp'),
 
     'time_connected': ('Connect Dauer',
                        'Connect duration',
@@ -219,8 +219,15 @@ STR_TABLE = {
     'cmd_help_lcstatus': ('Verbundene Terminalkanäle anzeigen (ausführliche Version)',
                           'Show connected terminal channels (detailed version)',
                           'Toon lekker aangesloten terminalkanalen (gedetailleerde versie)'),
-    'cli_no_wx_data': ('Keine Wetterdaten vorhanden.', 'No WX data available', 'No WX data available'),
-    'cli_no_data': ('Keine Daten vorhanden.', 'No data available.', 'No data available.'),
-    'cli_no_tracer_data': ('Keine Tracerdaten vorhanden.', 'No Tracer data available', 'No Tracer data available'),
+    'cli_no_wx_data': ('Keine Wetterdaten vorhanden.', 'No WX data available', 'Geen lekker WX beschikbaar.'),
+    'cli_no_data': ('Keine Daten vorhanden.', 'No data available.', 'Geen gegevens beschikbaar.'),
+    'cli_no_tracer_data': ('Keine Tracerdaten vorhanden.', 'No Tracer data available', 'Geen tracergegevens beschikbaar.'),
+    'cli_change_language': ('Sprache ändern.', 'Change language.', 'Lekker taal veranderen'),
+    'cli_lang_set': ('Sprache auf Deutsch geändert.',
+                     'Language changed to English.',
+                     'Taal veranderd naar lekker Nederlands.'),
+    'cli_no_lang_param': ('Sprache nicht erkannt! Mögliche Sprachen: ',
+                          'Language not recognized! Possible languages: ',
+                          'Taal niet herkend! Mogelijke talen: '),
 
 }

--- a/string_tab.py
+++ b/string_tab.py
@@ -201,6 +201,9 @@ STR_TABLE = {
     'port_overview': ('Port Übersicht',
                       'Port Overview',
                       'Lekker Ports'),
+    'cmd_shelp': ('Kurzhilfe',
+                  'Short help',
+                  'Lekker Short Helpye'),
 
     'time_connected': ('Connect Dauer',
                        'Connect duration',
@@ -217,6 +220,7 @@ STR_TABLE = {
                           'Show connected terminal channels (detailed version)',
                           'Toon lekker aangesloten terminalkanalen (gedetailleerde versie)'),
     'cli_no_wx_data': ('Keine Wetterdaten vorhanden.', 'No WX data available', 'No WX data available'),
+    'cli_no_data': ('Keine Daten vorhanden.', 'No data available.', 'No data available.'),
     'cli_no_tracer_data': ('Keine Tracerdaten vorhanden.', 'No Tracer data available', 'No Tracer data available'),
 
 }


### PR DESCRIPTION
Fixes:
- CLI Kommando "ATR", Call & Port sind vertauscht
- UserDB Fenster: Eintrag wird nicht gespeichert beim Auswählen eines
  anderen Eintrag.
- Global (rechte Seite) Zeilenabstände korrigiert.
- Routen werden in GUI MH-Liste nicht angezeigt.

Optimierung:
- CLI Kommando "ATR" Ausgabe
- CLI Kommando "WX" Detail Ausgabe zur Station. Mit dem Befehl "wx call" können jetzt
  die Datenpunkte der jeweiligen WX-Station angezeigt werden. (Standard Länge 10) (wx call länge)
  z.B. "WX CB0SAW-14 20"
- Locator und Distanz Spalte zu MH Liste hinzugefügt
- Distanz Spalte zu MH Liste (rechte Seite) hinzugefügt
- Cleanups
- DX-Alarm verbessert. Optional einstellbar nach Entfernung, Neuer Call,
  zuletzt gesehen vor .. Tagen und oder Ports
- MH-Listen: Empfangene Digis auf einer Route werden Jetzt auch in der MH Lister erfasst
- CLI Kommando "MH": Nicht direkt empfangene Stationen werden mit ein * gekennzeichnet.
- Alle direkt empfangene Stationen (auch auf einer Route direkt empfangene DIGIs) werden
  automatisch zur User-DB hinzugefügt. "DIGIs" werden vorerst als TYP "DIGI" eingetragen,
  solange kein anderer Eintrag vorliegt.
- Bei unvollständiger Eingabe von CLI Befehl werden alle möglichen Befehle vorgeschlagen.

Neue Implementierungen / Funktionen:
- CLI Kommando "AXIP": Listet aller bekannten AXIP Stationen und deren AXIP Adresse auf.
- CLI Kommando "LANG": Ändert die Spracheinstellung der CLI. Vorerst möglich DE, EN, NL.
  (Übersetzungen sind teilweise noch nicht vollständig oder gemixt (Denglisch))
- CLI Kommando "?": "Kurzhilfe" Listet aller bekannten Befehle auf.
- CLI Kommando "DXLIST": "DX/Tracer Alarm Historie" Listet aller DX/Tracer Alarme.
- "Auto-Tracer": APRS-Tracer Bake wird in eingestellten Intervallen über eine
  einstellbare Periode ausgesendet, sobald ein MH-Liste DX-Alarm getriggert wird.
  So kann die "TX-Seite" der Funkstrecken automatisch "überprüft" werden.
  Allerdings kann die Tracer-Bake nur die APRS Infrastruktur nutzen und ist somit
  auf APRS-DIGIs und APRS I-Gates angewiesen um eine Auswertung vornehmen zu können.
  Die Bake wird über das APRS WIDE-System (WIDE DIGI Regeln) solange weiter geleitet
  bis es von ein I-Gate aufgenommen wird.
  Bei Verbindung zu einem APRS-Server wird die zurück kommende Tracer-Bake
  nach gesendeten Pfad, Laufzeiten und empfangenen I-Gate ausgewertet.
  Zusätzlich wird auch der HF Verkehr auf die zurück kommende Tracer-Bake überwacht
  und die empfangenen APRS-Digis, Pfade und Laufzeit ausgewertet.
  Der Auto-Tracer kann nicht aktiviert werden wenn der Tracer ehe schon läuft und
  somit ehe schon die Tracer-Bake regelmäßig ausgesendet wird oder wenn der DX-Alarm
  nicht aktiviert ist.